### PR TITLE
frontend_host_ should be destructed after devtools_web_contents_.

### DIFF
--- a/browser/inspectable_web_contents_impl.h
+++ b/browser/inspectable_web_contents_impl.h
@@ -76,10 +76,10 @@ private:
   virtual void HandleKeyboardEvent(content::WebContents*, const content::NativeWebKeyboardEvent&) OVERRIDE;
   
   scoped_ptr<content::WebContents> web_contents_;
+  scoped_ptr<content::DevToolsClientHost> frontend_host_;
   scoped_ptr<content::WebContents> devtools_web_contents_;
   scoped_ptr<InspectableWebContentsView> view_;
   scoped_refptr<content::DevToolsAgentHost> agent_host_;
-  scoped_ptr<content::DevToolsClientHost> frontend_host_;
   std::string dock_side_;
 
   DISALLOW_COPY_AND_ASSIGN(InspectableWebContentsImpl);


### PR DESCRIPTION
When `devtools_web_contents_` is destructed, the `InspectableWebContentsImpl::WebContentsDestroyed` would then be called, and in which `frontend_host_` is used.

However since `frontend_host_` was declared after `devtools_web_contents_`, it would be destructed before `devtools_web_contents_`, so when the `WebContentsDestroyed` is called in the destructor of `InspectableWebContents`, the `frontend_host_` has already been destroyed, and would result in a crash like this:

```
Crashed Thread:  0  CrBrowserMain  Dispatch queue: com.apple.main-thread

Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Codes: KERN_INVALID_ADDRESS at 0x00000000179e7b81

VM Regions Near 0x179e7b81:
    MALLOC_LARGE           000000000e06f000-000000000e575000 [ 5144K] rw-/rwx SM=PRV  
--> 
    Memory tag=255         000000002a900000-000000002a909000 [   36K] rw-/rwx SM=COW  

Thread 0 Crashed:: CrBrowserMain  Dispatch queue: com.apple.main-thread
0   Atom                            0x0010913b base::DefaultDeleter<content::DevToolsClientHost>::operator()(content::DevToolsClientHost*) const + 43 (scoped_ptr.h:137)
1   Atom                            0x001090f5 base::internal::scoped_ptr_impl<content::DevToolsClientHost, base::DefaultDeleter<content::DevToolsClientHost> >::reset(content::DevToolsClientHost*) + 101 (scoped_ptr.h:247)
2   Atom                            0x00108dd4 scoped_ptr<content::DevToolsClientHost, base::DefaultDeleter<content::DevToolsClientHost> >::reset(content::DevToolsClientHost*) + 36 (scoped_ptr.h:367)
3   Atom                            0x001089cd brightray::InspectableWebContentsImpl::WebContentsDestroyed(content::WebContents*) + 173 (inspectable_web_contents_impl.cc:146)
4   Atom                            0x00108a09 non-virtual thunk to brightray::InspectableWebContentsImpl::WebContentsDestroyed(content::WebContents*) + 41 (inspectable_web_contents_impl.cc:146)
5   libchromiumcontent.dylib        0x015ea212 content::WebContentsObserver::WebContentsImplDestroyed() + 50
6   libchromiumcontent.dylib        0x017fe2b8 content::WebContentsImpl::~WebContentsImpl() + 1688
7   libchromiumcontent.dylib        0x017fdae1 content::WebContentsImpl::~WebContentsImpl() + 17
8   Atom                            0x001091fe base::DefaultDeleter<content::WebContents>::operator()(content::WebContents*) const + 46 (scoped_ptr.h:138)
9   Atom                            0x00109752 base::internal::scoped_ptr_impl<content::WebContents, base::DefaultDeleter<content::WebContents> >::~scoped_ptr_impl() + 50 (scoped_ptr.h:222)
10  Atom                            0x00109717 base::internal::scoped_ptr_impl<content::WebContents, base::DefaultDeleter<content::WebContents> >::~scoped_ptr_impl() + 23 (scoped_ptr.h:222)
11  Atom                            0x001096f7 scoped_ptr<content::WebContents, base::DefaultDeleter<content::WebContents> >::~scoped_ptr() + 23 (scoped_ptr.h:310)
12  Atom                            0x00108cc7 scoped_ptr<content::WebContents, base::DefaultDeleter<content::WebContents> >::~scoped_ptr() + 23 (scoped_ptr.h:310)
13  Atom                            0x00107d13 brightray::InspectableWebContentsImpl::~InspectableWebContentsImpl() + 163 (inspectable_web_contents_impl.cc:48)
14  Atom                            0x00107ba7 brightray::InspectableWebContentsImpl::~InspectableWebContentsImpl() + 23 (inspectable_web_contents_impl.cc:48)
15  Atom                            0x00107b7a brightray::InspectableWebContentsImpl::~InspectableWebContentsImpl() + 26 (inspectable_web_contents_impl.cc:47)
16  Atom                            0x000e6a0e base::DefaultDeleter<brightray::InspectableWebContents>::operator()(brightray::InspectableWebContents*) const + 46 (scoped_ptr.h:138)
17  Atom                            0x000e69d2 base::internal::scoped_ptr_impl<brightray::InspectableWebContents, base::DefaultDeleter<brightray::InspectableWebContents> >::~scoped_ptr_impl() + 50 (scoped_ptr.h:222)
18  Atom                            0x000e6997 base::internal::scoped_ptr_impl<brightray::InspectableWebContents, base::DefaultDeleter<brightray::InspectableWebContents> >::~scoped_ptr_impl() + 23 (scoped_ptr.h:222)
19  Atom                            0x000e6977 scoped_ptr<brightray::InspectableWebContents, base::DefaultDeleter<brightray::InspectableWebContents> >::~scoped_ptr() + 23 (scoped_ptr.h:310)
20  Atom                            0x000e2e27 scoped_ptr<brightray::InspectableWebContents, base::DefaultDeleter<brightray::InspectableWebContents> >::~scoped_ptr() + 23 (scoped_ptr.h:310)
21  Atom                            0x000e0fef atom::NativeWindow::~NativeWindow() + 239 (native_window.cc:57)
```
