### PR TITLE
Add GetRemoteDebuggingPort virtual function for BrowserMainParts.

### DIFF
--- a/browser/browser_main_parts.cc
+++ b/browser/browser_main_parts.cc
@@ -25,13 +25,17 @@ void BrowserMainParts::PreMainMessageLoopRun() {
 
   // These two objects are owned by devtools_http_handler_.
   auto delegate = new DevToolsDelegate;
-  auto factory = new net::TCPListenSocketFactory("127.0.0.1", 0);
+  auto factory = new net::TCPListenSocketFactory("127.0.0.1", GetRemoteDebuggingPort());
 
   devtools_http_handler_ = content::DevToolsHttpHandler::Start(factory, std::string(), delegate);
 }
 
 BrowserContext* BrowserMainParts::CreateBrowserContext() {
   return new BrowserContext;
+}
+
+int BrowserMainParts::GetRemoteDebuggingPort() {
+  return 0;
 }
 
 }

--- a/browser/browser_main_parts.h
+++ b/browser/browser_main_parts.h
@@ -30,6 +30,14 @@ protected:
   // takes ownership of the returned object.
   virtual BrowserContext* CreateBrowserContext();
 
+  // Subclasses should override this if they want to set a fixed remote debugging port for the
+  // devtools. By default it returns 0, which means a random port would be picked.
+  //
+  // One important reason of why you would override this is that the devtools's settings can only
+  // be persitent when you provide a fixed remote debugging port, because the settings are stored
+  // in localStorage, which uses 'address:port' to mark each storage cell.
+  virtual int GetRemoteDebuggingPort();
+
 #if defined(OS_MACOSX)
   virtual void PreMainMessageLoopStart() OVERRIDE;
 #endif


### PR DESCRIPTION
The devtools uses localStorage to store settings, and localStorage uses `address:port` to mark each storage cell, so the devtools's settings can only be saved when a fixed remote debugging port is provided.
