### PR TITLE
Improve Windows default build settings

### DIFF
--- a/brightray.gypi
+++ b/brightray.gypi
@@ -180,6 +180,11 @@
             'WarnAsError': 'true',
             'DebugInformationFormat': '3',
           },
+          'VCLinkerTool': {
+            'GenerateDebugInformation': 'true',
+            'MapFileName': '$(OutDir)\\$(TargetName).map',
+            'ImportLibrary': '$(OutDir)\\lib\\$(TargetName).lib',
+          },
         },
         'msvs_disabled_warnings': [
           4100, # unreferenced formal parameter


### PR DESCRIPTION
We had a bug preventing our build settings being used at all. This fixes that, and adds some more defaults.
