### PR TITLE
Fix building with ninja

### DIFF
--- a/brightray.gyp
+++ b/brightray.gyp
@@ -2,6 +2,9 @@
   'includes': [
     'brightray.gypi',
   ],
+  'variables': {
+    'brightray_source_root': '<!(python tools/brightray_source_root.py)',
+  },
   'targets': [
     {
       'target_name': 'brightray',
@@ -70,7 +73,7 @@
         ['OS=="mac"', {
           'link_settings': {
             'libraries': [
-              'libchromiumcontent.dylib',
+              '<(brightray_source_root)/<(libchromiumcontent_library_dir)/libchromiumcontent.dylib',
               '$(SDKROOT)/System/Library/Frameworks/AppKit.framework',
             ],
           },
@@ -78,9 +81,9 @@
         ['OS=="win"', {
           'link_settings': {
             'libraries': [
-              '<(libchromiumcontent_library_dir)/base_static.lib',
-              '<(libchromiumcontent_library_dir)/chromiumcontent.dll.lib',
-              '<(libchromiumcontent_library_dir)/sandbox_static.lib',
+              '<(brightray_source_root)/<(libchromiumcontent_library_dir)/base_static.lib',
+              '<(brightray_source_root)/<(libchromiumcontent_library_dir)/chromiumcontent.dll.lib',
+              '<(brightray_source_root)/<(libchromiumcontent_library_dir)/sandbox_static.lib',
             ],
           },
         }],

--- a/tools/brightray_source_root.py
+++ b/tools/brightray_source_root.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+import os
+
+"""Prints the absolute path of the root of brightray's source tree.
+"""
+
+
+print os.path.abspath(os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
This PR fixes linking errors when building with ninja by using absolute path for external libraries. 
