### PR TITLE
include library dependencies explicitly

### DIFF
--- a/brightray.gyp
+++ b/brightray.gyp
@@ -90,6 +90,8 @@
           'link_settings': {
             'libraries': [
               '<(brightray_source_root)/<(libchromiumcontent_library_dir)/libchromiumcontent.so',
+              '-lpthread',
+              '<!@(pkg-config --libs gtk+-2.0)',
             ],
           },
         }],


### PR DESCRIPTION
More recent versions of Clang, e.g. on Debian unstable, don't pick up the fact that `libchromiumcontent.so` wants pthread, GTK, etc.  So we add them as explicit dependencies for any app that uses brightray.
