### PR TITLE
make BrowserContext::Initialize virtual

### DIFF
--- a/browser/browser_context.h
+++ b/browser/browser_context.h
@@ -22,7 +22,7 @@ class BrowserContext : public content::BrowserContext {
   BrowserContext();
   ~BrowserContext();
 
-  void Initialize();
+  virtual void Initialize();
 
   net::URLRequestContextGetter* CreateRequestContext(
       content::ProtocolHandlerMap*);


### PR DESCRIPTION
I need to be able to override `BrowserContext::Initialize()` in applications.  So I made it virtual.
