### PR TITLE
The 'ARCHS' key should be an array.

### DIFF
--- a/brightray.gypi
+++ b/brightray.gypi
@@ -31,7 +31,7 @@
   'target_defaults': {
     'xcode_settings': {
       'ALWAYS_SEARCH_USER_PATHS': 'NO',
-      'ARCHS': '$(ARCHS_STANDARD_64_BIT)',
+      'ARCHS': ['x86_64'],
       'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++11',
       'CLANG_CXX_LIBRARY': 'libstdc++',
       'COMBINE_HIDPI_IMAGES': 'YES',


### PR DESCRIPTION
The ninja generator only supports setting the 'ARCHS' key as array, and ninja does not support '$(ARCHS_STANDARD_64_BIT)' too. The 'x86_64' is accepted by both ninja and xcodebuild, and is also used by node.
