### PR TITLE
Increase the open file limit on OS X to 1024

### DIFF
--- a/browser/browser_main_parts.h
+++ b/browser/browser_main_parts.h
@@ -27,6 +27,7 @@ class BrowserMainParts : public content::BrowserMainParts {
   virtual BrowserContext* CreateBrowserContext();
 
 #if defined(OS_MACOSX)
+  virtual void PreEarlyInitialization() OVERRIDE;
   virtual void PreMainMessageLoopStart() OVERRIDE;
 #endif
 

--- a/browser/browser_main_parts_mac.mm
+++ b/browser/browser_main_parts_mac.mm
@@ -1,9 +1,39 @@
 #import "browser_main_parts.h"
 
+#import "base/logging.h"
 #import "base/mac/bundle_locations.h"
 #import <AppKit/AppKit.h>
 
 namespace brightray {
+
+namespace {
+
+// Sets the file descriptor soft limit to |max_descriptors| or the OS hard limit, whichever is
+// lower.
+void SetFileDescriptorLimit(rlim_t max_descriptors) {
+  rlimit limits;
+  if (getrlimit(RLIMIT_NOFILE, &limits) != 0) {
+    PLOG(INFO) << "Failed to get file descriptor limit";
+    return;
+  }
+
+  auto new_limit = max_descriptors;
+  if (limits.rlim_max > 0)
+    new_limit = std::min(new_limit, limits.rlim_max);
+  limits.rlim_cur = new_limit;
+  if (setrlimit(RLIMIT_NOFILE, &limits) != 0)
+    PLOG(INFO) << "Failed to set file descriptor limit";
+}
+
+}  // namespace
+
+void BrowserMainParts::PreEarlyInitialization() {
+  // We use quite a few file descriptors for our IPC, and the default limit on the Mac is low (256),
+  // so bump it up.
+  // See http://src.chromium.org/viewvc/chrome/trunk/src/chrome/browser/chrome_browser_main_posix.cc?revision=244734#l295
+  // and https://codereview.chromium.org/125151
+  SetFileDescriptorLimit(1024);
+}
 
 // Replicates NSApplicationMain, but doesn't start a run loop.
 void BrowserMainParts::PreMainMessageLoopStart() {


### PR DESCRIPTION
The default (256) is too low for pages that load a lot of resources all at once. See https://codereview.chromium.org/125151 and bugs like https://code.google.com/p/chromium/issues/detail?id=14137 and https://code.google.com/p/chromium/issues/detail?id=151039. The new limit matches what Chrome itself uses.
