### PR TITLE
Closing detached window should mark devtools as not visible

### DIFF
--- a/browser/mac/bry_inspectable_web_contents_view.mm
+++ b/browser/mac/bry_inspectable_web_contents_view.mm
@@ -232,6 +232,7 @@ void SetActive(content::WebContents* web_contents, bool active) {
 #pragma mark - NSWindowDelegate
 
 - (BOOL)windowShouldClose:(id)sender {
+  _private->visible = NO;
   [_private->window orderOut:nil];
   return NO;
 }


### PR DESCRIPTION
Otherwise devtools would still be thought as opened when it is closed via clicking the close button.
