### PR TITLE
remember position and size of developer tools window

### DIFF
--- a/browser/mac/bry_inspectable_web_contents_view.mm
+++ b/browser/mac/bry_inspectable_web_contents_view.mm
@@ -188,7 +188,7 @@ void SetActive(content::WebContents* web_contents, bool active) {
   if (!devToolsWebContents)
     return NO;
   auto devToolsView = devToolsWebContents->GetView()->GetNativeView();
-
+  
   return _private->window && devToolsView.window == _private->window;
 }
 
@@ -200,7 +200,7 @@ void SetActive(content::WebContents* web_contents, bool active) {
     SetActive(inspectable_contents->devtools_web_contents(), active);
     return;
   }
-
+  
   // Changes the window that hosts us always affect our main web contents. If the dev tools are also
   // hosted in this window, they are affected too.
   SetActive(inspectable_contents->GetWebContents(), active);


### PR DESCRIPTION
it's nice when quitting and relaunching an app a whole bunch during debugging to have things come back up the way you last had it.  this change enables that for a detatched dev tools window on mac.  the downside is multiple dev tools windows will all come back up in the same place, as they will all share the same frameAutosaveName.
