### PR TITLE
mac: Close devtools when web contents is destroyed.

### DIFF
--- a/browser/inspectable_web_contents_view_mac.mm
+++ b/browser/inspectable_web_contents_view_mac.mm
@@ -17,6 +17,7 @@ InspectableWebContentsViewMac::InspectableWebContentsViewMac(InspectableWebConte
 }
 
 InspectableWebContentsViewMac::~InspectableWebContentsViewMac() {
+  CloseDevTools();
 }
 
 gfx::NativeView InspectableWebContentsViewMac::GetNativeView() const {


### PR DESCRIPTION
After the `BRYInspectableWebContentsView` is added as subview to other `NSWindow` owned by users, the `view_` would not be dealloc when the web contents got destroyed, which made the devtools window a ghost until user's `NSWindow` got released.

Fixes https://github.com/atom/atom-shell/issues/559.
