### PR TITLE
Same as https://github.com/atom/atom-shell/pull/867

### DIFF
--- a/brightray.gyp
+++ b/brightray.gyp
@@ -3,7 +3,7 @@
     'brightray.gypi',
   ],
   'variables': {
-    'brightray_source_root': '<!(python tools/brightray_source_root.py)',
+    'brightray_source_root': '<!(["python", "tools/brightray_source_root.py"])',
   },
   'targets': [
     {


### PR DESCRIPTION
Indeed there are two places worth changing. After these two changes i am able to build Atom-Shell using Pyhon installed by default (without adding to PATH)
