### PR TITLE
Fix the default Framework name

### DIFF
--- a/common/main_delegate_mac.mm
+++ b/common/main_delegate_mac.mm
@@ -33,7 +33,7 @@ base::FilePath MainDelegate::GetResourcesPakFilePath() {
 }
 
 void MainDelegate::OverrideFrameworkBundlePath() {
-  base::FilePath helper_path = GetFrameworksPath().Append(GetApplicationName() + ".framework");
+  base::FilePath helper_path = GetFrameworksPath().Append(GetApplicationName() + " Framework.framework");
 
   base::mac::SetOverrideFrameworkBundlePath(helper_path);
 }


### PR DESCRIPTION
At some point, Atom changed from using 'Atom.framework' to using 'Atom Framework.framework'. 
