### PR TITLE
Update to brightray.gyp : libresolv

### DIFF
--- a/brightray.gyp
+++ b/brightray.gyp
@@ -134,7 +134,7 @@
                   '$(SDKROOT)/System/Library/Frameworks/Foundation.framework',
                   '$(SDKROOT)/System/Library/Frameworks/Security.framework',
                   '$(SDKROOT)/System/Library/Frameworks/SystemConfiguration.framework',
-                  '$(SDKROOT)/usr/lib/libresolv.dylib',
+                  '-lresolv',
                   # media.gyp:
                   '$(SDKROOT)/System/Library/Frameworks/AudioToolbox.framework',
                   '$(SDKROOT)/System/Library/Frameworks/AudioUnit.framework',


### PR DESCRIPTION
In Following with this PR https://github.com/atom/brightray/pull/153
@joshaber helped me to work out this was causing a build error Xcode 7 for libresolv
