### PR TITLE
Notify osd detector

### DIFF
--- a/browser/linux/libnotify_loader.cc
+++ b/browser/linux/libnotify_loader.cc
@@ -38,6 +38,15 @@ bool LibNotifyLoader::Load(const std::string& library_name) {
     return false;
   }
 
+  notify_get_server_info =
+      reinterpret_cast<decltype(this->notify_get_server_info)>(
+          dlsym(library_, "notify_get_server_info"));
+  notify_get_server_info = &::notify_get_server_info;
+  if (!notify_get_server_info) {
+    CleanUp(true);
+    return false;
+  }
+
   notify_notification_new =
       reinterpret_cast<decltype(this->notify_notification_new)>(
           dlsym(library_, "notify_notification_new"));
@@ -104,6 +113,7 @@ void LibNotifyLoader::CleanUp(bool unload) {
   loaded_ = false;
   notify_is_initted = NULL;
   notify_init = NULL;
+  notify_get_server_info = NULL;
   notify_notification_new = NULL;
   notify_notification_add_action = NULL;
   notify_notification_set_image_from_pixbuf = NULL;

--- a/browser/linux/libnotify_loader.h
+++ b/browser/linux/libnotify_loader.h
@@ -20,6 +20,7 @@ class LibNotifyLoader {
 
   decltype(&::notify_is_initted) notify_is_initted;
   decltype(&::notify_init) notify_init;
+  decltype(&::notify_get_server_info) notify_get_server_info;
   decltype(&::notify_notification_new) notify_notification_new;
   decltype(&::notify_notification_add_action) notify_notification_add_action;
   decltype(&::notify_notification_set_image_from_pixbuf) notify_notification_set_image_from_pixbuf;

--- a/browser/linux/libnotify_notification.cc
+++ b/browser/linux/libnotify_notification.cc
@@ -15,32 +15,29 @@
 namespace brightray {
 
 namespace {
+LibNotifyLoader libnotify_loader_;
 
-bool unity_has_result = false;
-bool unity_result = false;
-
-bool UnityIsRunning() {
+bool NotifyOSDIsRunning() {
   if (getenv("ELECTRON_USE_UBUNTU_NOTIFIER"))
     return true;
 
-  if (unity_has_result)
-    return unity_result;
+  static bool notify_has_result = false;
+  static bool notify_result = false;
+  char *notifier_name = NULL;
 
-  unity_has_result = true;
+  if (notify_has_result)
+    return notify_result;
 
-  // Look for the presence of libunity as our hint that we're under Ubuntu.
-  base::FileEnumerator enumerator(base::FilePath("/usr/lib"),
-                                  false, base::FileEnumerator::FILES);
-  base::FilePath haystack;
-  while (!((haystack = enumerator.Next()).empty())) {
-    if (base::StartsWith(haystack.value(), "/usr/lib/libunity-",
-                         base::CompareCase::SENSITIVE)) {
-      unity_result = true;
-      break;
+  if (libnotify_loader_.notify_get_server_info(&notifier_name, NULL, NULL, NULL)) {
+    notify_has_result = true;
+
+    if (g_strcmp0(notifier_name, "notify-osd") == 0) {
+      notify_result = true;
     }
   }
 
-  return unity_result;
+  g_free(notifier_name);
+  return notify_result;
 }
 
 void log_and_clear_error(GError* error, const char* context) {
@@ -58,9 +55,6 @@ Notification* Notification::Create(NotificationDelegate* delegate,
                                    NotificationPresenter* presenter) {
   return new LibnotifyNotification(delegate, presenter);
 }
-
-// static
-LibNotifyLoader LibnotifyNotification::libnotify_loader_;
 
 // static
 bool LibnotifyNotification::Initialize() {
@@ -103,7 +97,7 @@ void LibnotifyNotification::Show(const base::string16& title,
   // to display as a modal dialog box. Testing for distros that have "Unity
   // Zen Nature" is difficult, we will test for the presence of the indicate
   // dbus service
-  if (!UnityIsRunning()) {
+  if (!NotifyOSDIsRunning()) {
     libnotify_loader_.notify_notification_add_action(
         notification_, "default", "View", OnNotificationViewThunk, this,
         nullptr);

--- a/browser/linux/libnotify_notification.cc
+++ b/browser/linux/libnotify_notification.cc
@@ -93,10 +93,8 @@ void LibnotifyNotification::Show(const base::string16& title,
   g_signal_connect(
       notification_, "closed", G_CALLBACK(OnNotificationClosedThunk), this);
 
-  // NB: On Unity, adding a notification action will cause the notification
-  // to display as a modal dialog box. Testing for distros that have "Unity
-  // Zen Nature" is difficult, we will test for the presence of the indicate
-  // dbus service
+  // NB: On Unity and on any other DE using Notify-OSD, adding a notification
+  // action will cause the notification to display as a modal dialog box.
   if (!NotifyOSDIsRunning()) {
     libnotify_loader_.notify_notification_add_action(
         notification_, "default", "View", OnNotificationViewThunk, this,

--- a/browser/linux/libnotify_notification.cc
+++ b/browser/linux/libnotify_notification.cc
@@ -77,6 +77,7 @@ LibnotifyNotification::LibnotifyNotification(NotificationDelegate* delegate,
 }
 
 LibnotifyNotification::~LibnotifyNotification() {
+  g_signal_handlers_disconnect_by_data(notification_, this);
   g_object_unref(notification_);
 }
 

--- a/browser/linux/libnotify_notification.h
+++ b/browser/linux/libnotify_notification.h
@@ -35,8 +35,6 @@ class LibnotifyNotification : public Notification {
 
   void NotificationFailed();
 
-  static LibNotifyLoader libnotify_loader_;
-
   NotifyNotification* notification_;
 
   DISALLOW_COPY_AND_ASSIGN(LibnotifyNotification);


### PR DESCRIPTION
Use notify_get_server_info to detect if notify-osd is running instead of looking for libunity presence.

Fixes https://github.com/electron/electron/issues/465