### PR TITLE
Notify check actions cap

### DIFF
--- a/browser/linux/libnotify_loader.cc
+++ b/browser/linux/libnotify_loader.cc
@@ -47,6 +47,15 @@ bool LibNotifyLoader::Load(const std::string& library_name) {
     return false;
   }
 
+  notify_get_server_caps =
+      reinterpret_cast<decltype(this->notify_get_server_caps)>(
+          dlsym(library_, "notify_get_server_caps"));
+  notify_get_server_caps = &::notify_get_server_caps;
+  if (!notify_get_server_caps) {
+    CleanUp(true);
+    return false;
+  }
+
   notify_notification_new =
       reinterpret_cast<decltype(this->notify_notification_new)>(
           dlsym(library_, "notify_notification_new"));
@@ -114,6 +123,7 @@ void LibNotifyLoader::CleanUp(bool unload) {
   notify_is_initted = NULL;
   notify_init = NULL;
   notify_get_server_info = NULL;
+  notify_get_server_caps = NULL;
   notify_notification_new = NULL;
   notify_notification_add_action = NULL;
   notify_notification_set_image_from_pixbuf = NULL;

--- a/browser/linux/libnotify_loader.cc
+++ b/browser/linux/libnotify_loader.cc
@@ -38,6 +38,15 @@ bool LibNotifyLoader::Load(const std::string& library_name) {
     return false;
   }
 
+  notify_get_server_info =
+      reinterpret_cast<decltype(this->notify_get_server_info)>(
+          dlsym(library_, "notify_get_server_info"));
+  notify_get_server_info = &::notify_get_server_info;
+  if (!notify_get_server_info) {
+    CleanUp(true);
+    return false;
+  }
+
   notify_notification_new =
       reinterpret_cast<decltype(this->notify_notification_new)>(
           dlsym(library_, "notify_notification_new"));
@@ -104,6 +113,7 @@ void LibNotifyLoader::CleanUp(bool unload) {
   loaded_ = false;
   notify_is_initted = NULL;
   notify_init = NULL;
+  notify_get_server_info = NULL;
   notify_notification_new = NULL;
   notify_notification_add_action = NULL;
   notify_notification_set_image_from_pixbuf = NULL;

--- a/browser/linux/libnotify_loader.h
+++ b/browser/linux/libnotify_loader.h
@@ -20,6 +20,7 @@ class LibNotifyLoader {
 
   decltype(&::notify_is_initted) notify_is_initted;
   decltype(&::notify_init) notify_init;
+  decltype(&::notify_get_server_info) notify_get_server_info;
   decltype(&::notify_notification_new) notify_notification_new;
   decltype(&::notify_notification_add_action) notify_notification_add_action;
   decltype(&::notify_notification_set_image_from_pixbuf) notify_notification_set_image_from_pixbuf;

--- a/browser/linux/libnotify_loader.h
+++ b/browser/linux/libnotify_loader.h
@@ -20,6 +20,7 @@ class LibNotifyLoader {
 
   decltype(&::notify_is_initted) notify_is_initted;
   decltype(&::notify_init) notify_init;
+  decltype(&::notify_get_server_caps) notify_get_server_caps;
   decltype(&::notify_get_server_info) notify_get_server_info;
   decltype(&::notify_notification_new) notify_notification_new;
   decltype(&::notify_notification_add_action) notify_notification_add_action;

--- a/browser/linux/libnotify_notification.h
+++ b/browser/linux/libnotify_notification.h
@@ -35,8 +35,6 @@ class LibnotifyNotification : public Notification {
 
   void NotificationFailed();
 
-  static LibNotifyLoader libnotify_loader_;
-
   NotifyNotification* notification_;
 
   DISALLOW_COPY_AND_ASSIGN(LibnotifyNotification);


### PR DESCRIPTION
This is alternative to PR https://github.com/electron/brightray/pull/209 by using a more generic way to verify whether the current notifier supports the `actions` capability or not.
Check the [specs](https://developer.gnome.org/notification-spec/) for more infos.

Fixes https://github.com/electron/electron/issues/465