### PR TITLE
Notifications tags

### DIFF
--- a/browser/linux/libnotify_notification.cc
+++ b/browser/linux/libnotify_notification.cc
@@ -119,6 +119,11 @@ void LibnotifyNotification::Show(const base::string16& title,
     g_object_unref(pixbuf);
   }
 
+  if (!tag.empty()) {
+    GQuark id = g_quark_from_string(tag.c_str());
+    g_object_set(G_OBJECT(notification_), "id", id, NULL);
+  }
+
   GError* error = nullptr;
   libnotify_loader_.notify_notification_show(notification_, &error);
   if (error) {

--- a/browser/linux/libnotify_notification.cc
+++ b/browser/linux/libnotify_notification.cc
@@ -88,6 +88,7 @@ LibnotifyNotification::~LibnotifyNotification() {
 
 void LibnotifyNotification::Show(const base::string16& title,
                                  const base::string16& body,
+                                 const std::string& tag,
                                  const GURL& icon_url,
                                  const SkBitmap& icon,
                                  const bool silent) {

--- a/browser/linux/libnotify_notification.h
+++ b/browser/linux/libnotify_notification.h
@@ -22,6 +22,7 @@ class LibnotifyNotification : public Notification {
   // Notification:
   void Show(const base::string16& title,
             const base::string16& msg,
+            const std::string& tag,
             const GURL& icon_url,
             const SkBitmap& icon,
             const bool silent) override;

--- a/browser/mac/cocoa_notification.h
+++ b/browser/mac/cocoa_notification.h
@@ -22,6 +22,7 @@ class CocoaNotification : public Notification {
   // Notification:
   void Show(const base::string16& title,
             const base::string16& msg,
+            const std::string& tag,
             const GURL& icon_url,
             const SkBitmap& icon,
             const bool silent) override;

--- a/browser/mac/cocoa_notification.mm
+++ b/browser/mac/cocoa_notification.mm
@@ -30,6 +30,7 @@ CocoaNotification::~CocoaNotification() {
 
 void CocoaNotification::Show(const base::string16& title,
                              const base::string16& body,
+                             const std::string& tag,
                              const GURL& icon_url,
                              const SkBitmap& icon,
                              const bool silent) {

--- a/browser/notification.h
+++ b/browser/notification.h
@@ -21,6 +21,7 @@ class Notification {
   // Shows the notification.
   virtual void Show(const base::string16& title,
                     const base::string16& msg,
+                    const std::string& tag,
                     const GURL& icon_url,
                     const SkBitmap& icon,
                     const bool silent) = 0;

--- a/browser/platform_notification_service.cc
+++ b/browser/platform_notification_service.cc
@@ -37,7 +37,7 @@ void OnWebNotificationAllowed(
   auto notification = presenter->CreateNotification(adapter.get());
   if (notification) {
     ignore_result(adapter.release());  // it will release itself automatically.
-    notification->Show(data.title, data.body, data.icon, icon, data.silent);
+    notification->Show(data.title, data.body, data.tag, data.icon, icon, data.silent);
     *cancel_callback = base::Bind(&RemoveNotification, notification);
   }
 }

--- a/browser/win/windows_toast_notification.cc
+++ b/browser/win/windows_toast_notification.cc
@@ -84,6 +84,7 @@ WindowsToastNotification::~WindowsToastNotification() {
 void WindowsToastNotification::Show(
     const base::string16& title,
     const base::string16& msg,
+    const std::string& tag,
     const GURL& icon_url,
     const SkBitmap& icon,
     const bool silent) {

--- a/browser/win/windows_toast_notification.h
+++ b/browser/win/windows_toast_notification.h
@@ -41,6 +41,7 @@ class WindowsToastNotification : public Notification {
   // Notification:
   void Show(const base::string16& title,
             const base::string16& msg,
+            const std::string& tag,
             const GURL& icon_url,
             const SkBitmap& icon,
             const bool silent) override;


### PR DESCRIPTION
LibnotifyNotification: add support for notification tag

We set the id of the notification if tag is provided.
As per the [protocol](https://developer.gnome.org/notification-spec/#protocol), this should cause the old notification with same ID to be replaced.