### PR TITLE
Linux notifications append

### DIFF
--- a/browser/linux/libnotify_loader.cc
+++ b/browser/linux/libnotify_loader.cc
@@ -92,6 +92,15 @@ bool LibNotifyLoader::Load(const std::string& library_name) {
     return false;
   }
 
+  notify_notification_set_hint_string =
+      reinterpret_cast<decltype(this->notify_notification_set_hint_string)>(
+          dlsym(library_, "notify_notification_set_hint_string"));
+  notify_notification_set_hint_string = &::notify_notification_set_hint_string;
+  if (!notify_notification_set_hint_string) {
+    CleanUp(true);
+    return false;
+  }
+
   notify_notification_show =
       reinterpret_cast<decltype(this->notify_notification_show)>(
           dlsym(library_, "notify_notification_show"));
@@ -128,6 +137,7 @@ void LibNotifyLoader::CleanUp(bool unload) {
   notify_notification_add_action = NULL;
   notify_notification_set_image_from_pixbuf = NULL;
   notify_notification_set_timeout = NULL;
+  notify_notification_set_hint_string = NULL;
   notify_notification_show = NULL;
   notify_notification_close = NULL;
 }

--- a/browser/linux/libnotify_loader.h
+++ b/browser/linux/libnotify_loader.h
@@ -26,6 +26,7 @@ class LibNotifyLoader {
   decltype(&::notify_notification_add_action) notify_notification_add_action;
   decltype(&::notify_notification_set_image_from_pixbuf) notify_notification_set_image_from_pixbuf;
   decltype(&::notify_notification_set_timeout) notify_notification_set_timeout;
+  decltype(&::notify_notification_set_hint_string) notify_notification_set_hint_string;
   decltype(&::notify_notification_show) notify_notification_show;
   decltype(&::notify_notification_close) notify_notification_close;
 

--- a/browser/linux/libnotify_notification.cc
+++ b/browser/linux/libnotify_notification.cc
@@ -121,6 +121,16 @@ void LibnotifyNotification::Show(const base::string16& title,
     g_object_set(G_OBJECT(notification_), "id", id, NULL);
   }
 
+  // Always try to append notifications.
+  // Unique tags can be used to prevent this.
+  if (HasCapability("append")) {
+    libnotify_loader_.notify_notification_set_hint_string(
+        notification_, "append", "true");
+  } else if (HasCapability("x-canonical-append")) {
+    libnotify_loader_.notify_notification_set_hint_string(
+        notification_, "x-canonical-append", "true");
+  }
+
   GError* error = nullptr;
   libnotify_loader_.notify_notification_show(notification_, &error);
   if (error) {

--- a/browser/linux/libnotify_notification.cc
+++ b/browser/linux/libnotify_notification.cc
@@ -17,6 +17,18 @@ namespace brightray {
 namespace {
 LibNotifyLoader libnotify_loader_;
 
+bool HasCapability(const std::string& capability) {
+  bool result = false;
+  GList* capabilities = libnotify_loader_.notify_get_server_caps();
+
+  if (g_list_find_custom(capabilities, capability.c_str(), (GCompareFunc) g_strcmp0) != NULL)
+    result = true;
+
+  g_list_free_full(capabilities, g_free);
+
+  return result;
+}
+
 bool NotifierSupportsActions() {
   if (getenv("ELECTRON_USE_UBUNTU_NOTIFIER"))
     return false;
@@ -28,12 +40,7 @@ bool NotifierSupportsActions() {
   if (notify_has_result)
     return notify_result;
 
-  capabilities = libnotify_loader_.notify_get_server_caps();
-
-  if (g_list_find_custom(capabilities, "actions", (GCompareFunc) g_strcmp0) != NULL)
-    notify_result = true;
-
-  g_list_free_full(capabilities, g_free);
+  notify_result = HasCapability("actions");
   return notify_result;
 }
 


### PR DESCRIPTION
Use `append` for linux notifications when supported.
This would allow multiple notifications that respects [these rules](https://wiki.ubuntu.com/NotifyOSD#Merging_notifications), to be merged in a single bubble.

Electron developers could prevent this by just providing a notification using an unique `tag` (`new Notification("foo", {tag: unique_id})` would work).
Unfortunately there's no an easy way to allow developers to pass hints to notifications, since the `data` field at seems to be a `SerializedScriptValue` which can't be deserialized at brightray level (without reimplementing some blink internals).

Fixes https://github.com/electron/electron/issues/5052