### PR TITLE
Ensure ELECTRON_USE_UBUNTU_NOTIFIER really works

### DIFF
--- a/browser/linux/libnotify_notification.cc
+++ b/browser/linux/libnotify_notification.cc
@@ -31,7 +31,7 @@ bool HasCapability(const std::string& capability) {
 
 bool NotifierSupportsActions() {
   if (getenv("ELECTRON_USE_UBUNTU_NOTIFIER"))
-    return false;
+    return true;
 
   static bool notify_has_result = false;
   static bool notify_result = false;


### PR DESCRIPTION
Fix a typo caused in a previous PR, when the ELECTRON_USE_UBUNTU_NOTIFIER env variable is exported, we've to force the actions support.