### PR TITLE
Do not link with libnotify

### DIFF
--- a/brightray.gyp
+++ b/brightray.gyp
@@ -1,7 +1,7 @@
 {
   'variables': {
     # The libraries brightray will be compiled to.
-    'linux_system_libraries': 'gtk+-2.0 libnotify dbus-1 x11 xi xcursor xdamage xrandr xcomposite xext xfixes xrender xtst gconf-2.0 gmodule-2.0 nss'
+    'linux_system_libraries': 'gtk+-2.0 dbus-1 x11 xi xcursor xdamage xrandr xcomposite xext xfixes xrender xtst gconf-2.0 gmodule-2.0 nss'
   },
   'includes': [
     'filenames.gypi',

--- a/browser/linux/libnotify_notification.cc
+++ b/browser/linux/libnotify_notification.cc
@@ -15,6 +15,7 @@
 namespace brightray {
 
 namespace {
+
 LibNotifyLoader libnotify_loader_;
 
 bool HasCapability(const std::string& capability) {
@@ -35,7 +36,6 @@ bool NotifierSupportsActions() {
 
   static bool notify_has_result = false;
   static bool notify_result = false;
-  GList *capabilities = NULL;
 
   if (notify_has_result)
     return notify_result;
@@ -62,7 +62,8 @@ Notification* Notification::Create(NotificationDelegate* delegate,
 
 // static
 bool LibnotifyNotification::Initialize() {
-  if (!libnotify_loader_.Load("libnotify.so.4") &&
+  if (!libnotify_loader_.Load("libnotify.so.4") &&  // most common one
+      !libnotify_loader_.Load("libnotify.so.5") &&
       !libnotify_loader_.Load("libnotify.so.1") &&
       !libnotify_loader_.Load("libnotify.so")) {
     return false;


### PR DESCRIPTION
We are already loading it dynamically there is no meaning linking with the library anymore.

Close https://github.com/electron/electron/issues/5348.