### PR TITLE
Revert "Replace --whole-archive with --start-group"

### DIFF
--- a/brightray.gyp
+++ b/brightray.gyp
@@ -36,13 +36,14 @@
       'conditions': [
         # Link with libraries of libchromiumcontent.
         ['OS=="linux" and libchromiumcontent_component==0', {
-          # On Linux we have to use "--start-group" or we will have plenty of
+          # On Linux we have to use "--whole-archive" to force executable
+          # to include all symbols, otherwise we will have plenty of
           # unresolved symbols errors.
-          'link_settings': {
-            'libraries': [
-              '-Wl,--start-group',
+          'direct_dependent_settings': {
+            'ldflags': [
+              '-Wl,--whole-archive',
               '<@(libchromiumcontent_libraries)',
-              '-Wl,--end-group'
+              '-Wl,--no-whole-archive',
             ],
           }
         }, {  # (Release build on Linux)


### PR DESCRIPTION
Reverts electron/brightray#228.
Closes https://github.com/electron/electron/issues/6178.

It is causing crashes on Linux.