### PR TITLE
Fix IsDevToolsViewFocused on undocked windows

### DIFF
--- a/browser/views/inspectable_web_contents_view_views.cc
+++ b/browser/views/inspectable_web_contents_view_views.cc
@@ -142,7 +142,9 @@ bool InspectableWebContentsViewViews::IsDevToolsViewShowing() {
 }
 
 bool InspectableWebContentsViewViews::IsDevToolsViewFocused() {
-  if (devtools_web_view_)
+  if (devtools_window_web_view_)
+    return devtools_window_web_view_->HasFocus();
+  else if (devtools_web_view_)
     return devtools_web_view_->HasFocus();
   else
     return false;


### PR DESCRIPTION
On Windows and Linux, `InspectableWebContentsViewViews::IsDevToolsViewFocused` was previously always returning `false` when the devtools are undocked but focused.

This pull request updates it to check the focus state of the devtools windows web view when it is available.

/cc @zcbenz 