### PR TITLE
allow delegate to handle file and color chooser

### DIFF
--- a/browser/inspectable_web_contents_impl.cc
+++ b/browser/inspectable_web_contents_impl.cc
@@ -670,6 +670,33 @@ void InspectableWebContentsImpl::CloseContents(content::WebContents* source) {
   CloseDevTools();
 }
 
+content::ColorChooser* InspectableWebContentsImpl::OpenColorChooser(
+    content::WebContents* source,
+    SkColor color,
+    const std::vector<content::ColorSuggestion>& suggestions) {
+  auto delegate = web_contents_->GetDelegate();
+  if (delegate)
+    return delegate->OpenColorChooser(source, color, suggestions);
+  return nullptr;
+}
+
+void InspectableWebContentsImpl::RunFileChooser(
+    content::WebContents* source,
+    const content::FileChooserParams& params) {
+  auto delegate = web_contents_->GetDelegate();
+  if (delegate)
+    delegate->RunFileChooser(source, params);
+}
+
+void InspectableWebContentsImpl::EnumerateDirectory(
+    content::WebContents* source,
+    int request_id,
+    const base::FilePath& path) {
+  auto delegate = web_contents_->GetDelegate();
+  if (delegate)
+    delegate->EnumerateDirectory(source, request_id, path);
+}
+
 void InspectableWebContentsImpl::OnWebContentsFocused() {
 #if defined(TOOLKIT_VIEWS)
   if (view_->GetDelegate())

--- a/browser/inspectable_web_contents_impl.h
+++ b/browser/inspectable_web_contents_impl.h
@@ -153,6 +153,15 @@ class InspectableWebContentsImpl :
   void HandleKeyboardEvent(
       content::WebContents*, const content::NativeWebKeyboardEvent&) override;
   void CloseContents(content::WebContents* source) override;
+  content::ColorChooser* OpenColorChooser(
+      content::WebContents* source,
+      SkColor color,
+      const std::vector<content::ColorSuggestion>& suggestions) override;
+  void RunFileChooser(content::WebContents* source,
+                      const content::FileChooserParams& params) override;
+  void EnumerateDirectory(content::WebContents* source,
+                          int request_id,
+                          const base::FilePath& path) override;
 
   // net::URLFetcherDelegate:
   void OnURLFetchComplete(const net::URLFetcher* source) override;


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/6156


A side note,
* should `WebDialogHelper::EnumerateDirectory` required to be enumerate over `DIRECTORIES, INCLUDE_DOT_DOT` when its not recursive ?

* The current implementation causes render to terminate with  `RVH_CAN_ACCESS_FILES_OF_PAGE_STATE` because of `INCLUDE_DOT_DOT` in the result.

* Can we make the enumeration async using `net::DirectoryLister` or is the current implementation fine ?