### PR TITLE
Offscreen rendering support for Electron

### DIFF
--- a/brightray.gyp
+++ b/brightray.gyp
@@ -29,6 +29,7 @@
           '<(libchromiumcontent_src_dir)/third_party/skia/include/config',
           '<(libchromiumcontent_src_dir)/third_party/icu/source/common',
           '<(libchromiumcontent_src_dir)/third_party/mojo/src',
+          '<(libchromiumcontent_src_dir)/third_party/khronos',
           '<(libchromiumcontent_src_dir)/third_party/WebKit',
           '<(libchromiumcontent_dir)/gen',
         ],

--- a/browser/inspectable_web_contents_impl.cc
+++ b/browser/inspectable_web_contents_impl.cc
@@ -221,8 +221,14 @@ InspectableWebContentsImpl::InspectableWebContentsImpl(
       devtools_bounds_.set_width(800);
     }
     if (!IsPointInScreen(devtools_bounds_.origin())) {
-      gfx::Rect display = display::Screen::GetScreen()->
+      gfx::Rect display;
+      if (web_contents->GetNativeView()) {
+        display = display::Screen::GetScreen()->
           GetDisplayNearestWindow(web_contents->GetNativeView()).bounds();
+      } else {
+        display = display::Screen::GetScreen()->GetPrimaryDisplay().bounds();
+      }
+      
       devtools_bounds_.set_x(display.x() + (display.width() - devtools_bounds_.width()) / 2);
       devtools_bounds_.set_y(display.y() + (display.height() - devtools_bounds_.height()) / 2);
     }

--- a/common/main_delegate.cc
+++ b/common/main_delegate.cc
@@ -62,10 +62,16 @@ void InitializeResourceBundle(const std::string& locale) {
   bundle.AddDataPackFromPath(path, ui::GetSupportedScaleFactors()[0]);
 #if defined(OS_WIN)
   bundle.AddDataPackFromPath(
-      pak_dir.Append(FILE_PATH_LITERAL("ui_resources_200_percent.pak")),
+      pak_dir.Append(FILE_PATH_LITERAL("blink_image_resources_200_percent.pak")),
       ui::SCALE_FACTOR_200P);
   bundle.AddDataPackFromPath(
       pak_dir.Append(FILE_PATH_LITERAL("content_resources_200_percent.pak")),
+      ui::SCALE_FACTOR_200P);
+  bundle.AddDataPackFromPath(
+      pak_dir.Append(FILE_PATH_LITERAL("ui_resources_200_percent.pak")),
+      ui::SCALE_FACTOR_200P);
+  bundle.AddDataPackFromPath(
+      pak_dir.Append(FILE_PATH_LITERAL("views_resources_200_percent.pak")),
       ui::SCALE_FACTOR_200P);
 #endif
 }


### PR DESCRIPTION
This PR adds the necessary includes to the Chromium content module that are needed for offscreen rendering in Electron.

It depends on a custom *libchromiumcontent* fork, which is also submitted as a [PR](https://github.com/electron/libchromiumcontent/pull/226).

The [PR](https://github.com/electron/electron/pull/6691) in Electron.