### PR TITLE
initialize crypto delegate in CookieStoreConfig

### DIFF
--- a/brightray.gyp
+++ b/brightray.gyp
@@ -99,6 +99,8 @@
                   '<(libchromiumcontent_dir)/libyuv.a',
                   '<(libchromiumcontent_dir)/libcdm_renderer.a',
                   '<(libchromiumcontent_dir)/libsecurity_state.a',
+                  '<(libchromiumcontent_dir)/libcookie_config.a',
+                  '<(libchromiumcontent_dir)/libos_crypt.a',
                 ],
               },
             }, {
@@ -154,6 +156,8 @@
                   '<(libchromiumcontent_dir)/libyuv.a',
                   '<(libchromiumcontent_dir)/libcdm_renderer.a',
                   '<(libchromiumcontent_dir)/libsecurity_state.a',
+                  '<(libchromiumcontent_dir)/libcookie_config.a',
+                  '<(libchromiumcontent_dir)/libos_crypt.a',
                 ],
               },
             }, {
@@ -218,6 +222,8 @@
                   '<(libchromiumcontent_dir)/libyuv.lib',
                   '<(libchromiumcontent_dir)/cdm_renderer.lib',
                   '<(libchromiumcontent_dir)/security_state.lib',
+                  '<(libchromiumcontent_dir)/cookie_config.lib',
+                  '<(libchromiumcontent_dir)/os_crypt.lib',
                   # Friends of pdf.lib:
                   '<(libchromiumcontent_dir)/pdf.lib',
                   '<(libchromiumcontent_dir)/ppapi_cpp_objects.lib',

--- a/browser/url_request_context_getter.cc
+++ b/browser/url_request_context_getter.cc
@@ -17,6 +17,7 @@
 #include "base/strings/string_util.h"
 #include "base/threading/sequenced_worker_pool.h"
 #include "base/threading/worker_pool.h"
+#include "components/cookie_config/cookie_store_util.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/cookie_store_factory.h"
 #include "content/public/common/content_switches.h"
@@ -185,6 +186,7 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
           content::CookieStoreConfig::EPHEMERAL_SESSION_COOKIES,
           nullptr, nullptr);
       cookie_config.cookieable_schemes = delegate_->GetCookieableSchemes();
+      cookie_config.crypto_delegate = cookie_config::GetCookieCryptoDelegate();
       cookie_store = content::CreateCookieStore(cookie_config);
     }
     storage_->set_cookie_store(std::move(cookie_store));


### PR DESCRIPTION
Will encrypt persistent cookies committed after this patch, users will have to update their old cookies to encrypt them.

Depends on https://github.com/electron/libchromiumcontent/pull/229

Fixes https://github.com/electron/electron/issues/7073