### PR TITLE
Add verifiers for known certificate transparency logs

### DIFF
--- a/browser/url_request_context_getter.cc
+++ b/browser/url_request_context_getter.cc
@@ -25,7 +25,6 @@
 #include "net/cert/ct_known_logs.h"
 #include "net/cert/ct_log_verifier.h"
 #include "net/cert/ct_policy_enforcer.h"
-#include "net/cert/multi_log_ct_verifier.h"
 #include "net/cookies/cookie_monster.h"
 #include "net/dns/mapped_host_resolver.h"
 #include "net/http/http_auth_filter.h"
@@ -278,9 +277,9 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
         new net::HttpServerPropertiesImpl);
     storage_->set_http_server_properties(std::move(server_properties));
 
-    auto multi_log_ct_verifier = new net::MultiLogCTVerifier();
-    multi_log_ct_verifier->AddLogs(net::ct::CreateLogVerifiersForKnownLogs());
-    cert_transparency_verifier_.reset(multi_log_ct_verifier);
+    cert_transparency_verifier_.reset(new net::MultiLogCTVerifier());
+    cert_transparency_verifier_->AddLogs(
+        net::ct::CreateLogVerifiersForKnownLogs());
     ct_policy_enforcer_.reset(new net::CTPolicyEnforcer());
 
     net::HttpNetworkSession::Params network_session_params;

--- a/browser/url_request_context_getter.cc
+++ b/browser/url_request_context_getter.cc
@@ -22,6 +22,8 @@
 #include "content/public/common/content_switches.h"
 #include "net/base/host_mapping_rules.h"
 #include "net/cert/cert_verifier.h"
+#include "net/cert/ct_known_logs.h"
+#include "net/cert/ct_log_verifier.h"
 #include "net/cert/ct_policy_enforcer.h"
 #include "net/cert/multi_log_ct_verifier.h"
 #include "net/cookies/cookie_monster.h"
@@ -276,7 +278,9 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
         new net::HttpServerPropertiesImpl);
     storage_->set_http_server_properties(std::move(server_properties));
 
-    cert_transparency_verifier_.reset(new net::MultiLogCTVerifier());
+    auto multi_log_ct_verifier = new net::MultiLogCTVerifier();
+    multi_log_ct_verifier->AddLogs(net::ct::CreateLogVerifiersForKnownLogs());
+    cert_transparency_verifier_.reset(multi_log_ct_verifier);
     ct_policy_enforcer_.reset(new net::CTPolicyEnforcer());
 
     net::HttpNetworkSession::Params network_session_params;

--- a/browser/url_request_context_getter.h
+++ b/browser/url_request_context_getter.h
@@ -8,6 +8,7 @@
 #include "base/files/file_path.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/content_browser_client.h"
+#include "net/cert/multi_log_ct_verifier.h"
 #include "net/http/http_cache.h"
 #include "net/http/url_security_manager.h"
 #include "net/url_request/url_request_context_getter.h"
@@ -88,7 +89,7 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
   std::unique_ptr<net::HostMappingRules> host_mapping_rules_;
   std::unique_ptr<net::HttpAuthPreferences> http_auth_preferences_;
   std::unique_ptr<net::HttpNetworkSession> http_network_session_;
-  std::unique_ptr<net::CTVerifier> cert_transparency_verifier_;
+  std::unique_ptr<net::MultiLogCTVerifier> cert_transparency_verifier_;
   std::unique_ptr<net::CTPolicyEnforcer> ct_policy_enforcer_;
   content::ProtocolHandlerMap protocol_handlers_;
   content::URLRequestInterceptorScopedVector protocol_interceptors_;


### PR DESCRIPTION
This pull request implements option 3 from #248 to fix the `net::ERR_INSECURE_RESPONSE` error that are happening in Electron 1.4.0 for certain requests.

/cc @deepak1556 @sleevi do you think this is right approach until Brightray can use `URLRequestContextBuilder` directly?

Closes #248
Refs https://github.com/electron/electron/issues/7221
Upstream pull request https://github.com/electron/electron/pull/7292