### PR TITLE
Set CT related fields on URLRequestContextStorage

### DIFF
--- a/browser/url_request_context_getter.cc
+++ b/browser/url_request_context_getter.cc
@@ -46,6 +46,7 @@
 #include "net/url_request/file_protocol_handler.h"
 #include "net/url_request/static_http_user_agent_settings.h"
 #include "net/url_request/url_request_context.h"
+#include "net/url_request/url_request_context_builder.h"
 #include "net/url_request/url_request_context_storage.h"
 #include "net/url_request/url_request_intercepting_job_factory.h"
 #include "net/url_request/url_request_job_factory_impl.h"
@@ -285,22 +286,9 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
     storage_->set_ct_policy_enforcer(base::MakeUnique<net::CTPolicyEnforcer>());
 
     net::HttpNetworkSession::Params network_session_params;
-    network_session_params.cert_verifier = url_request_context_->cert_verifier();
-    network_session_params.proxy_service = url_request_context_->proxy_service();
-    network_session_params.ssl_config_service = url_request_context_->ssl_config_service();
-    network_session_params.http_server_properties = url_request_context_->http_server_properties();
+    net::URLRequestContextBuilder::SetHttpNetworkSessionComponents(
+        url_request_context_.get(), &network_session_params);
     network_session_params.ignore_certificate_errors = false;
-    network_session_params.transport_security_state =
-        url_request_context_->transport_security_state();
-    network_session_params.channel_id_service =
-        url_request_context_->channel_id_service();
-    network_session_params.http_auth_handler_factory =
-        url_request_context_->http_auth_handler_factory();
-    network_session_params.net_log = url_request_context_->net_log();
-    network_session_params.cert_transparency_verifier =
-        url_request_context_->cert_transparency_verifier();
-    network_session_params.ct_policy_enforcer =
-        url_request_context_->ct_policy_enforcer();
 
     // --disable-http2
     if (command_line.HasSwitch(switches::kDisableHttp2)) {

--- a/browser/url_request_context_getter.cc
+++ b/browser/url_request_context_getter.cc
@@ -25,6 +25,7 @@
 #include "net/cert/ct_known_logs.h"
 #include "net/cert/ct_log_verifier.h"
 #include "net/cert/ct_policy_enforcer.h"
+#include "net/cert/multi_log_ct_verifier.h"
 #include "net/cookies/cookie_monster.h"
 #include "net/dns/mapped_host_resolver.h"
 #include "net/http/http_auth_filter.h"

--- a/browser/url_request_context_getter.h
+++ b/browser/url_request_context_getter.h
@@ -8,7 +8,6 @@
 #include "base/files/file_path.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/content_browser_client.h"
-#include "net/cert/multi_log_ct_verifier.h"
 #include "net/http/http_cache.h"
 #include "net/http/url_security_manager.h"
 #include "net/url_request/url_request_context_getter.h"
@@ -89,8 +88,6 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
   std::unique_ptr<net::HostMappingRules> host_mapping_rules_;
   std::unique_ptr<net::HttpAuthPreferences> http_auth_preferences_;
   std::unique_ptr<net::HttpNetworkSession> http_network_session_;
-  std::unique_ptr<net::MultiLogCTVerifier> cert_transparency_verifier_;
-  std::unique_ptr<net::CTPolicyEnforcer> ct_policy_enforcer_;
   content::ProtocolHandlerMap protocol_handlers_;
   content::URLRequestInterceptorScopedVector protocol_interceptors_;
 


### PR DESCRIPTION
Follow up fix for #249 

Looks like there were a few fields only being set on the `net::HttpNetworkSession::Params` and not also set on the `net::URLRequestContextStorage` object that would cause a crash when missing there.

/cc @deepak1556 @sleevi 

Refs https://github.com/electron/electron/issues/7389