### PR TITLE
Link to electron instead of brightray_example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ use in applications.
 
 ## Using it in your app
 
-See [brightray_example](https://github.com/electron/brightray_example) for a
-sample application written using Brightray.
+See [electron](https://github.com/electron/electron) for example of an
+application written using Brightray.
 
 ## Development
 
@@ -33,9 +33,7 @@ You must previously have built and uploaded libchromiumcontent using its
     $ script/build
 
 Building Brightray on its own isn’t all that interesting, since it’s just a
-static library. Building it into an application (like
-[brightray_example](https://github.com/electron/brightray_example)) is the only
-way to test it.
+static library. Building it into an application is the only way to test it.
 
 ## License
 


### PR DESCRIPTION
[`brightray_example`](https://github.com/electron-archive/brightray_example) isn't up to date with the latest brightray changes and won't be maintained going forward.

Link directly to Electron as an example of an application using Brightray.