### PR TITLE
set notification close callback before requesting user permission

### DIFF
--- a/browser/linux/libnotify_notification.cc
+++ b/browser/linux/libnotify_notification.cc
@@ -146,6 +146,11 @@ void LibnotifyNotification::Show(const base::string16& title,
 }
 
 void LibnotifyNotification::Dismiss() {
+  if (!notification_) {
+    Destroy();
+    return;
+  }
+
   GError* error = nullptr;
   libnotify_loader_.notify_notification_close(notification_, &error);
   if (error) {

--- a/browser/linux/libnotify_notification.cc
+++ b/browser/linux/libnotify_notification.cc
@@ -82,8 +82,10 @@ LibnotifyNotification::LibnotifyNotification(NotificationDelegate* delegate,
 }
 
 LibnotifyNotification::~LibnotifyNotification() {
-  g_signal_handlers_disconnect_by_data(notification_, this);
-  g_object_unref(notification_);
+  if (notification_) {
+    g_signal_handlers_disconnect_by_data(notification_, this);
+    g_object_unref(notification_);
+  }
 }
 
 void LibnotifyNotification::Show(const base::string16& title,

--- a/browser/mac/cocoa_notification.mm
+++ b/browser/mac/cocoa_notification.mm
@@ -24,8 +24,9 @@ CocoaNotification::CocoaNotification(NotificationDelegate* delegate,
 }
 
 CocoaNotification::~CocoaNotification() {
-  [NSUserNotificationCenter.defaultUserNotificationCenter
-      removeDeliveredNotification:notification_];
+  if (notification_)
+    [NSUserNotificationCenter.defaultUserNotificationCenter
+        removeDeliveredNotification:notification_];
 }
 
 void CocoaNotification::Show(const base::string16& title,

--- a/browser/mac/cocoa_notification.mm
+++ b/browser/mac/cocoa_notification.mm
@@ -57,8 +57,9 @@ void CocoaNotification::Show(const base::string16& title,
 }
 
 void CocoaNotification::Dismiss() {
-  [NSUserNotificationCenter.defaultUserNotificationCenter
-      removeDeliveredNotification:notification_];
+  if (notification_)
+    [NSUserNotificationCenter.defaultUserNotificationCenter
+        removeDeliveredNotification:notification_];
   NotificationDismissed();
 }
 

--- a/browser/notification.h
+++ b/browser/notification.h
@@ -34,6 +34,9 @@ class Notification {
   void NotificationDismissed();
   void NotificationFailed();
 
+  // delete this.
+  void Destroy();
+
   base::WeakPtr<Notification> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();
   }
@@ -45,9 +48,6 @@ class Notification {
   Notification(NotificationDelegate* delegate,
                NotificationPresenter* presenter);
   virtual ~Notification();
-
-  // delete this.
-  void Destroy();
 
  private:
   friend class NotificationPresenter;

--- a/browser/platform_notification_service.cc
+++ b/browser/platform_notification_service.cc
@@ -26,12 +26,13 @@ void OnWebNotificationAllowed(base::WeakPtr<Notification> notification,
                               const content::PlatformNotificationData& data,
                               bool audio_muted,
                               bool allowed) {
-  if (!allowed) {
-    notification->Destroy();
+  if (!notification)
     return;
-  }
-  notification->Show(data.title, data.body, data.tag, data.icon, icon,
-                     audio_muted ? true : data.silent);
+  if (allowed)
+    notification->Show(data.title, data.body, data.tag, data.icon, icon,
+                       audio_muted ? true : data.silent);
+  else
+    notification->Destroy();
 }
 
 }  // namespace


### PR DESCRIPTION
Previously `cancel_callback` was instantiated after the object it was holding was destroyed, the patch creates notification and sets destructor for `notification.close` api before requesting user permission. Verified on linux only.

Fixes https://github.com/electron/electron/issues/7645

/cc @kevinsawicki @pfrazee
