### PR TITLE
force attach devtools client when requested by inspectable webcontents

### DIFF
--- a/browser/inspectable_web_contents.h
+++ b/browser/inspectable_web_contents.h
@@ -38,7 +38,7 @@ class InspectableWebContents {
   virtual void ShowDevTools() = 0;
   virtual void CloseDevTools() = 0;
   virtual bool IsDevToolsViewShowing() = 0;
-  virtual void AttachTo(const scoped_refptr<content::DevToolsAgentHost>&) = 0;
+  virtual void AttachTo(scoped_refptr<content::DevToolsAgentHost>) = 0;
   virtual void Detach() = 0;
   virtual void CallClientFunction(const std::string& function_name,
                                   const base::Value* arg1 = nullptr,

--- a/browser/inspectable_web_contents_impl.cc
+++ b/browser/inspectable_web_contents_impl.cc
@@ -279,8 +279,8 @@ void InspectableWebContentsImpl::ShowDevTools() {
     Observe(devtools_web_contents_.get());
     devtools_web_contents_->SetDelegate(this);
 
-    agent_host_ = content::DevToolsAgentHost::GetOrCreateFor(web_contents_.get());
-    agent_host_->AttachClient(this);
+    AttachTo(std::move(
+        content::DevToolsAgentHost::GetOrCreateFor(web_contents_.get())));
 
     devtools_web_contents_->GetController().LoadURL(
         GetDevToolsURL(can_dock_),
@@ -304,11 +304,13 @@ bool InspectableWebContentsImpl::IsDevToolsViewShowing() {
   return devtools_web_contents_ && view_->IsDevToolsViewShowing();
 }
 
-void InspectableWebContentsImpl::AttachTo(const scoped_refptr<content::DevToolsAgentHost>& host) {
+void InspectableWebContentsImpl::AttachTo(
+    scoped_refptr<content::DevToolsAgentHost> host) {
   if (agent_host_.get())
     Detach();
   agent_host_ = host;
-  agent_host_->AttachClient(this);
+  // Terminate existing debugging connections and start debugging.
+  agent_host_->ForceAttachClient(this);
 }
 
 void InspectableWebContentsImpl::Detach() {

--- a/browser/inspectable_web_contents_impl.h
+++ b/browser/inspectable_web_contents_impl.h
@@ -54,7 +54,7 @@ class InspectableWebContentsImpl :
   void ShowDevTools() override;
   void CloseDevTools() override;
   bool IsDevToolsViewShowing() override;
-  void AttachTo(const scoped_refptr<content::DevToolsAgentHost>&) override;
+  void AttachTo(scoped_refptr<content::DevToolsAgentHost>) override;
   void Detach() override;
   void CallClientFunction(const std::string& function_name,
                           const base::Value* arg1,


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/8336

The function signatures' where changed to reflect on https://chromium.googlesource.com/chromium/src/+/master/styleguide/c++/c++.md#Object-ownership-and-calling-conventions