### PR TITLE
Fix bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -58,9 +58,9 @@ def parse_args():
 
 
 def update_submodules():
-  return (subprocess.call(['git', 'submodule', 'sync', '--quiet']) or
+  return (subprocess.call(['git', 'submodule', 'sync', '--quiet'], cwd=SOURCE_ROOT) or
           subprocess.call(['git', 'submodule', 'update', '--init',
-                           '--recursive']))
+                           '--recursive', cwd=SOURCE_ROOT]))
 
 
 def setup_libchromiumcontent(is_dev, commit, target_arch, url,


### PR DESCRIPTION
Added cwd to the subprocess call as we ended up with the following issue:

In our setup, electron uses submodules based on branches and latest changes (bootstrap scripts are using --remote), but the electron bootstrap is calling brightray bootstrap which was overriding the changes made by the first git sync/update as it was running in the same electron folder.

This change is made so that it does not affect in any way current build process.