### PR TITLE
Cleanly shutdown browser context

### DIFF
--- a/browser/browser_context.cc
+++ b/browser/browser_context.cc
@@ -102,6 +102,8 @@ BrowserContext::BrowserContext(const std::string& partition, bool in_memory)
 }
 
 BrowserContext::~BrowserContext() {
+  NotifyWillBeDestroyed(this);
+  ShutdownStoragePartitions();
   BrowserThread::DeleteSoon(BrowserThread::IO,
                             FROM_HERE,
                             resource_context_.release());


### PR DESCRIPTION
Call `NotifyWillBeDestroyed(this)` and `ShutdownStoragePartitions()` in destructor.

As suggested by @deepak1556 in https://github.com/electron/electron/issues/8563#issuecomment-277227964

Refs https://codereview.chromium.org/653633004
Refs https://codereview.chromium.org/2159133002
Refs https://github.com/electron/electron/issues/8563