### PR TITLE
Revert "close devtools web contents when available to trigger cleanup"

### DIFF
--- a/browser/inspectable_web_contents_impl.cc
+++ b/browser/inspectable_web_contents_impl.cc
@@ -235,8 +235,6 @@ InspectableWebContentsImpl::InspectableWebContentsImpl(
 }
 
 InspectableWebContentsImpl::~InspectableWebContentsImpl() {
-  if (devtools_web_contents_)
-    devtools_web_contents_->Close();
   Observe(nullptr);
 }
 


### PR DESCRIPTION
Reverts electron/brightray#278

Refs electron/electron#8817

Seeing the following crash when this spec runs with this change, https://github.com/electron/electron/blob/6d45052eeaf57faf239523b1b328cf37281ae030/spec/webview-spec.js#L1080

```
0   libcontent.dylib                  0x000000011375fd5e content::BrowserPluginGuest::GetOwnerRenderWidgetHostView() + 14
1   libcontent.dylib                  0x0000000113867a53 content::RenderWidgetHostViewGuest::GetNativeView() const + 67
2   libcontent.dylib                  0x0000000113acba6a 0x113433000 + 6916714
3   com.github.electron.framework     0x000000010df41c72 brightray::InspectableWebContentsImpl::CloseDevTools() + 370 (inspectable_web_contents_impl.cc:308)
4   com.github.electron.framework     0x000000010df48e15 brightray::InspectableWebContentsImpl::CloseContents(content::WebContents*) + 37 (inspectable_web_contents_impl.cc:694)
5   com.github.electron.framework     0x000000010df40975 brightray::InspectableWebContentsImpl::~InspectableWebContentsImpl() + 261 (inspectable_web_contents_impl.cc:239)
6   com.github.electron.framework     0x000000010df40f55 brightray::InspectableWebContentsImpl::~InspectableWebContentsImpl() + 21 (inspectable_web_contents_impl.cc:241)
7   com.github.electron.framework     0x000000010df41039 brightray::InspectableWebContentsImpl::~InspectableWebContentsImpl() + 25 (inspectable_web_contents_impl.cc:237)
8   com.github.electron.framework     0x000000010dc4bc4f atom::CommonWebContentsDelegate::~CommonWebContentsDelegate() + 367 (memory:2783)
9   com.github.electron.framework     0x000000010dba5d0b atom::api::WebContents::~WebContents() + 683 (atom_api_web_contents.cc:420)
10  com.github.electron.framework     0x000000010dba5de5 atom::api::WebContents::~WebContents() + 21 (atom_api_web_contents.cc:420)
11  com.github.electron.framework     0x000000010dba5ee9 atom::api::WebContents::~WebContents() + 25 (atom_api_web_contents.cc:406)
12  com.github.electron.framework     0x000000010df01947 mate::internal::Destroyable::Destroy(mate::Arguments*) + 71 (function_template.h:25)
```

/cc @deepak1556 