### PR TITLE
Revert "Revert "close devtools web contents when available to trigger cleanup""

### DIFF
--- a/browser/inspectable_web_contents_impl.cc
+++ b/browser/inspectable_web_contents_impl.cc
@@ -235,6 +235,8 @@ InspectableWebContentsImpl::InspectableWebContentsImpl(
 }
 
 InspectableWebContentsImpl::~InspectableWebContentsImpl() {
+  if (devtools_web_contents_)
+    devtools_web_contents_->Close();
   Observe(nullptr);
 }
 


### PR DESCRIPTION
The crash has been fixed here https://github.com/electron/electron/pull/8923/commits/72adbf7a2fef7aaef83fb56db9d3e9ddacc99b3a

This reverts commit 7f01bf4e73c188db2406ded1286b661c61c78bba.