### PR TITLE
Detach from devtools before destroying

### DIFF
--- a/browser/inspectable_web_contents_impl.cc
+++ b/browser/inspectable_web_contents_impl.cc
@@ -235,7 +235,14 @@ InspectableWebContentsImpl::InspectableWebContentsImpl(
 }
 
 InspectableWebContentsImpl::~InspectableWebContentsImpl() {
-  Observe(nullptr);
+  // Unsubscribe from devtools and Clean up resources.
+  if (devtools_web_contents_) {
+    devtools_web_contents_->SetDelegate(nullptr);
+    // Calling this also unsubscribes the observer, so WebContentsDestroyed
+    // won't be called again.
+    WebContentsDestroyed();
+  }
+  // Let destructor destroy devtools_web_contents_.
 }
 
 InspectableWebContentsView* InspectableWebContentsImpl::GetView() const {
@@ -646,6 +653,7 @@ void InspectableWebContentsImpl::RenderFrameHostChanged(
 
 void InspectableWebContentsImpl::WebContentsDestroyed() {
   frontend_loaded_ = false;
+  Observe(nullptr);
   Detach();
 
   for (const auto& pair : pending_requests_)
@@ -688,6 +696,7 @@ void InspectableWebContentsImpl::HandleKeyboardEvent(
 }
 
 void InspectableWebContentsImpl::CloseContents(content::WebContents* source) {
+  // This is where the devtools closes itself (by clicking the x button).
   CloseDevTools();
 }
 


### PR DESCRIPTION
This also fix a memory leak when closing a window with devtools opened.

Close https://github.com/electron/electron/issues/8817.