### PR TITLE
Run cpplint on CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+# Defines the Chromium style for automatic reformatting.
+# http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+BasedOnStyle: Chromium
+# This defaults to 'Auto'. Explicitly set it for a while, so that
+# 'vector<vector<int> >' in existing files gets formatted to
+# 'vector<vector<int>>'. ('Auto' means that clang-format will only use
+# 'int>>' if the file already contains at least one such instance.)
+Standard: Cpp11

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "vendor/gyp"]
 	path = vendor/gyp
 	url = https://github.com/electron/gyp
-[submodule "vendor/google-styleguide"]
-	path = vendor/google-styleguide
-	url = https://github.com/svn2github/sgss-mirror-google-styleguide

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,2 +1,1 @@
 filter=-build/header_guard,-build/include_what_you_use,-legal/copyright,-runtime/references
-linelength=100

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,2 @@
+filter=-build/header_guard,-build/include_what_you_use,-legal/copyright,-runtime/references
+linelength=100

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ platform:
 install:
   - cmd: SET PATH=C:\Program Files (x86)\MSBuild\14.0\bin\;%PATH%
   - cmd: SET PATH=C:\python27;%PATH%
+  - cmd: git submodule update --init --recursive
   - cmd: bash script/cibuild
 
 branches:

--- a/browser/browser_client.cc
+++ b/browser/browser_client.cc
@@ -68,7 +68,8 @@ content::MediaObserver* BrowserClient::GetMediaObserver() {
   return MediaCaptureDevicesDispatcher::GetInstance();
 }
 
-content::PlatformNotificationService* BrowserClient::GetPlatformNotificationService() {
+content::PlatformNotificationService*
+BrowserClient::GetPlatformNotificationService() {
   if (!notification_service_)
     notification_service_.reset(new PlatformNotificationService(this));
   return notification_service_.get();

--- a/browser/browser_client.h
+++ b/browser/browser_client.h
@@ -39,7 +39,8 @@ class BrowserClient : public content::ContentBrowserClient {
   content::BrowserMainParts* CreateBrowserMainParts(
       const content::MainFunctionParams&) override;
   content::MediaObserver* GetMediaObserver() override;
-  content::PlatformNotificationService* GetPlatformNotificationService() override;
+  content::PlatformNotificationService* GetPlatformNotificationService()
+      override;
   void GetAdditionalAllowedSchemesForFileSystem(
       std::vector<std::string>* additional_schemes) override;
   net::NetLog* GetNetLog() override;

--- a/browser/browser_context.cc
+++ b/browser/browser_context.cc
@@ -94,7 +94,8 @@ BrowserContext::BrowserContext(const std::string& partition, bool in_memory)
 
   if (!in_memory_ && !partition.empty())
     path_ = path_.Append(FILE_PATH_LITERAL("Partitions"))
-                 .Append(base::FilePath::FromUTF8Unsafe(MakePartitionName(partition)));
+                .Append(base::FilePath::FromUTF8Unsafe(
+                    MakePartitionName(partition)));
 
   content::BrowserContext::Initialize(this, path_);
 
@@ -168,8 +169,8 @@ base::FilePath BrowserContext::GetPath() const {
   return path_;
 }
 
-std::unique_ptr<content::ZoomLevelDelegate> BrowserContext::CreateZoomLevelDelegate(
-    const base::FilePath& partition_path) {
+std::unique_ptr<content::ZoomLevelDelegate>
+BrowserContext::CreateZoomLevelDelegate(const base::FilePath& partition_path) {
   if (!IsOffTheRecord()) {
     return base::MakeUnique<ZoomLevelDelegate>(prefs(), partition_path);
   }
@@ -210,7 +211,8 @@ content::PermissionManager* BrowserContext::GetPermissionManager() {
   return permission_manager_.get();
 }
 
-content::BackgroundSyncController* BrowserContext::GetBackgroundSyncController() {
+content::BackgroundSyncController*
+BrowserContext::GetBackgroundSyncController() {
   return nullptr;
 }
 

--- a/browser/inspectable_web_contents.h
+++ b/browser/inspectable_web_contents.h
@@ -18,7 +18,8 @@ class InspectableWebContentsView;
 
 class InspectableWebContents {
  public:
-  static InspectableWebContents* Create(const content::WebContents::CreateParams&);
+  static InspectableWebContents* Create(
+      const content::WebContents::CreateParams&);
 
   // The returned InspectableWebContents takes ownership of the passed-in
   // WebContents.

--- a/browser/inspectable_web_contents_impl.cc
+++ b/browser/inspectable_web_contents_impl.cc
@@ -136,7 +136,8 @@ GURL GetDevToolsURL(bool can_dock) {
 
 class ResponseWriter : public net::URLFetcherResponseWriter {
  public:
-  ResponseWriter(base::WeakPtr<InspectableWebContentsImpl> bindings, int stream_id);
+  ResponseWriter(base::WeakPtr<InspectableWebContentsImpl> bindings,
+                 int stream_id);
   ~ResponseWriter() override;
 
   // URLFetcherResponseWriter overrides:
@@ -153,8 +154,9 @@ class ResponseWriter : public net::URLFetcherResponseWriter {
   DISALLOW_COPY_AND_ASSIGN(ResponseWriter);
 };
 
-ResponseWriter::ResponseWriter(base::WeakPtr<InspectableWebContentsImpl> bindings,
-                               int stream_id)
+ResponseWriter::ResponseWriter(
+    base::WeakPtr<InspectableWebContentsImpl> bindings,
+    int stream_id)
     : bindings_(bindings),
       stream_id_(stream_id) {
 }
@@ -207,7 +209,8 @@ InspectableWebContentsImpl::InspectableWebContentsImpl(
       delegate_(nullptr),
       web_contents_(web_contents),
       weak_factory_(this) {
-  auto context = static_cast<BrowserContext*>(web_contents_->GetBrowserContext());
+  auto context =
+      static_cast<BrowserContext*>(web_contents_->GetBrowserContext());
   pref_service_ = context->prefs();
   auto bounds_dict = pref_service_->GetDictionary(kDevToolsBoundsPref);
   if (bounds_dict) {
@@ -226,8 +229,10 @@ InspectableWebContentsImpl::InspectableWebContentsImpl(
         display = display::Screen::GetScreen()->GetPrimaryDisplay().bounds();
       }
 
-      devtools_bounds_.set_x(display.x() + (display.width() - devtools_bounds_.width()) / 2);
-      devtools_bounds_.set_y(display.y() + (display.height() - devtools_bounds_.height()) / 2);
+      devtools_bounds_.set_x(display.x() +
+                             (display.width() - devtools_bounds_.width()) / 2);
+      devtools_bounds_.set_y(
+          display.y() + (display.height() - devtools_bounds_.height()) / 2);
     }
   }
 
@@ -246,7 +251,8 @@ content::WebContents* InspectableWebContentsImpl::GetWebContents() const {
   return web_contents_.get();
 }
 
-content::WebContents* InspectableWebContentsImpl::GetDevToolsWebContents() const {
+content::WebContents* InspectableWebContentsImpl::GetDevToolsWebContents()
+    const {
   return devtools_web_contents_.get();
 }
 
@@ -255,11 +261,13 @@ void InspectableWebContentsImpl::InspectElement(int x, int y) {
     agent_host_->InspectElement(this, x, y);
 }
 
-void InspectableWebContentsImpl::SetDelegate(InspectableWebContentsDelegate* delegate) {
+void InspectableWebContentsImpl::SetDelegate(
+    InspectableWebContentsDelegate* delegate) {
   delegate_ = delegate;
 }
 
-InspectableWebContentsDelegate* InspectableWebContentsImpl::GetDelegate() const {
+InspectableWebContentsDelegate* InspectableWebContentsImpl::GetDelegate()
+    const {
   return delegate_;
 }
 
@@ -279,7 +287,8 @@ void InspectableWebContentsImpl::ShowDevTools() {
     embedder_message_dispatcher_.reset(
         DevToolsEmbedderMessageDispatcher::CreateForDevToolsFrontend(this));
 
-    content::WebContents::CreateParams create_params(web_contents_->GetBrowserContext());
+    content::WebContents::CreateParams create_params(
+        web_contents_->GetBrowserContext());
     devtools_web_contents_.reset(content::WebContents::Create(create_params));
 
     Observe(devtools_web_contents_.get());
@@ -324,10 +333,11 @@ void InspectableWebContentsImpl::Detach() {
   agent_host_ = nullptr;
 }
 
-void InspectableWebContentsImpl::CallClientFunction(const std::string& function_name,
-                                                    const base::Value* arg1,
-                                                    const base::Value* arg2,
-                                                    const base::Value* arg3) {
+void InspectableWebContentsImpl::CallClientFunction(
+    const std::string& function_name,
+    const base::Value* arg1,
+    const base::Value* arg2,
+    const base::Value* arg3) {
   if (!devtools_web_contents_)
     return;
 
@@ -433,15 +443,17 @@ void InspectableWebContentsImpl::LoadNetworkResource(
     return;
   }
 
-  auto browser_context = static_cast<BrowserContext*>(devtools_web_contents_->GetBrowserContext());
+  auto browser_context =
+      static_cast<BrowserContext*>(devtools_web_contents_->GetBrowserContext());
 
   net::URLFetcher* fetcher =
       (net::URLFetcher::Create(gurl, net::URLFetcher::GET, this)).release();
   pending_requests_[fetcher] = callback;
   fetcher->SetRequestContext(browser_context->url_request_context_getter());
   fetcher->SetExtraRequestHeaders(headers);
-  fetcher->SaveResponseWithWriter(std::unique_ptr<net::URLFetcherResponseWriter>(
-      new ResponseWriter(weak_factory_.GetWeakPtr(), stream_id)));
+  fetcher->SaveResponseWithWriter(
+      std::unique_ptr<net::URLFetcherResponseWriter>(
+          new ResponseWriter(weak_factory_.GetWeakPtr(), stream_id)));
   fetcher->Start();
 }
 
@@ -509,7 +521,8 @@ void InspectableWebContentsImpl::SearchInPath(
     delegate_->DevToolsSearchInPath(request_id, file_system_path, query);
 }
 
-void InspectableWebContentsImpl::SetWhitelistedShortcuts(const std::string& message) {
+void InspectableWebContentsImpl::SetWhitelistedShortcuts(
+    const std::string& message) {
 }
 
 void InspectableWebContentsImpl::ZoomIn() {
@@ -548,16 +561,18 @@ void InspectableWebContentsImpl::DispatchProtocolMessageFromDevToolsFrontend(
     agent_host_->DispatchProtocolMessage(this, message);
 }
 
-void InspectableWebContentsImpl::RecordActionUMA(const std::string& name, int action) {
+void InspectableWebContentsImpl::RecordActionUMA(const std::string& name,
+                                                 int action) {
   if (name == kDevToolsActionTakenHistogram)
     UMA_HISTOGRAM_ENUMERATION(name, action, kDevToolsActionTakenBoundary);
   else if (name == kDevToolsPanelShownHistogram)
     UMA_HISTOGRAM_ENUMERATION(name, action, kDevToolsPanelShownBoundary);
 }
 
-void InspectableWebContentsImpl::SendJsonRequest(const DispatchCallback& callback,
-                                         const std::string& browser_id,
-                                         const std::string& url) {
+void InspectableWebContentsImpl::SendJsonRequest(
+    const DispatchCallback& callback,
+    const std::string& browser_id,
+    const std::string& url) {
   callback.Run(nullptr);
 }
 
@@ -584,7 +599,8 @@ void InspectableWebContentsImpl::ClearPreferences() {
   update.Get()->Clear();
 }
 
-void InspectableWebContentsImpl::HandleMessageFromDevToolsFrontend(const std::string& message) {
+void InspectableWebContentsImpl::HandleMessageFromDevToolsFrontend(
+    const std::string& message) {
   std::string method;
   base::ListValue empty_params;
   base::ListValue* params = &empty_params;
@@ -728,14 +744,14 @@ void InspectableWebContentsImpl::OnWebContentsFocused() {
 void InspectableWebContentsImpl::DidStartNavigationToPendingEntry(
     const GURL& url,
     content::ReloadType reload_type) {
-  frontend_host_.reset(
-      content::DevToolsFrontendHost::Create(
-          web_contents()->GetMainFrame(),
-          base::Bind(&InspectableWebContentsImpl::HandleMessageFromDevToolsFrontend,
-                     base::Unretained(this))));
+  frontend_host_.reset(content::DevToolsFrontendHost::Create(
+      web_contents()->GetMainFrame(),
+      base::Bind(&InspectableWebContentsImpl::HandleMessageFromDevToolsFrontend,
+                 base::Unretained(this))));
 }
 
-void InspectableWebContentsImpl::OnURLFetchComplete(const net::URLFetcher* source) {
+void InspectableWebContentsImpl::OnURLFetchComplete(
+    const net::URLFetcher* source) {
   DCHECK(source);
   auto it = pending_requests_.find(source);
   DCHECK(it != pending_requests_.end());

--- a/browser/inspectable_web_contents_impl.h
+++ b/browser/inspectable_web_contents_impl.h
@@ -173,7 +173,8 @@ class InspectableWebContentsImpl :
   bool frontend_loaded_;
   scoped_refptr<content::DevToolsAgentHost> agent_host_;
   std::unique_ptr<content::DevToolsFrontendHost> frontend_host_;
-  std::unique_ptr<DevToolsEmbedderMessageDispatcher> embedder_message_dispatcher_;
+  std::unique_ptr<DevToolsEmbedderMessageDispatcher>
+      embedder_message_dispatcher_;
 
   DevToolsContentsResizingStrategy contents_resizing_strategy_;
   gfx::Rect devtools_bounds_;

--- a/browser/linux/libnotify_loader.cc
+++ b/browser/linux/libnotify_loader.cc
@@ -1,5 +1,6 @@
 // This is generated file. Do not modify directly.
-// Path to the code generator: tools/generate_library_loader/generate_library_loader.py .
+// Path to the code generator:
+// tools/generate_library_loader/generate_library_loader.py .
 
 #include "browser/linux/libnotify_loader.h"
 
@@ -68,9 +69,9 @@ bool LibNotifyLoader::Load(const std::string& library_name) {
     return false;
   }
 
-  notify_notification_set_image_from_pixbuf =
-      reinterpret_cast<decltype(this->notify_notification_set_image_from_pixbuf)>(
-          dlsym(library_, "notify_notification_set_image_from_pixbuf"));
+  notify_notification_set_image_from_pixbuf = reinterpret_cast<decltype(
+      this->notify_notification_set_image_from_pixbuf)>(
+      dlsym(library_, "notify_notification_set_image_from_pixbuf"));
   if (!notify_notification_set_image_from_pixbuf) {
     CleanUp(true);
     return false;

--- a/browser/linux/libnotify_loader.h
+++ b/browser/linux/libnotify_loader.h
@@ -1,5 +1,6 @@
 // This is generated file. Do not modify directly.
-// Path to the code generator: tools/generate_library_loader/generate_library_loader.py .
+// Path to the code generator:
+// tools/generate_library_loader/generate_library_loader.py .
 
 #ifndef BRIGHTRAY_BROWSER_LINUX_LIBNOTIFY_LOADER_H_
 #define BRIGHTRAY_BROWSER_LINUX_LIBNOTIFY_LOADER_H_
@@ -24,9 +25,11 @@ class LibNotifyLoader {
   decltype(&::notify_get_server_info) notify_get_server_info;
   decltype(&::notify_notification_new) notify_notification_new;
   decltype(&::notify_notification_add_action) notify_notification_add_action;
-  decltype(&::notify_notification_set_image_from_pixbuf) notify_notification_set_image_from_pixbuf;
+  decltype(&::notify_notification_set_image_from_pixbuf)
+      notify_notification_set_image_from_pixbuf;
   decltype(&::notify_notification_set_timeout) notify_notification_set_timeout;
-  decltype(&::notify_notification_set_hint_string) notify_notification_set_hint_string;
+  decltype(&::notify_notification_set_hint_string)
+      notify_notification_set_hint_string;
   decltype(&::notify_notification_show) notify_notification_show;
   decltype(&::notify_notification_close) notify_notification_close;
 

--- a/browser/linux/libnotify_loader.h
+++ b/browser/linux/libnotify_loader.h
@@ -4,9 +4,9 @@
 #ifndef BRIGHTRAY_BROWSER_LINUX_LIBNOTIFY_LOADER_H_
 #define BRIGHTRAY_BROWSER_LINUX_LIBNOTIFY_LOADER_H_
 
-#include <string>
-
 #include <libnotify/notify.h>
+
+#include <string>
 
 class LibNotifyLoader {
  public:

--- a/browser/linux/libnotify_notification.cc
+++ b/browser/linux/libnotify_notification.cc
@@ -22,7 +22,8 @@ bool HasCapability(const std::string& capability) {
   bool result = false;
   GList* capabilities = libnotify_loader_.notify_get_server_caps();
 
-  if (g_list_find_custom(capabilities, capability.c_str(), (GCompareFunc) g_strcmp0) != NULL)
+  if (g_list_find_custom(capabilities, capability.c_str(),
+                         (GCompareFunc)g_strcmp0) != NULL)
     result = true;
 
   g_list_free_full(capabilities, g_free);

--- a/browser/media/media_stream_devices_controller.cc
+++ b/browser/media/media_stream_devices_controller.cc
@@ -142,10 +142,12 @@ void MediaStreamDevicesController::Accept() {
 
   content::MediaResponseCallback cb = callback_;
   callback_.Reset();
-  cb.Run(devices, content::MEDIA_DEVICE_OK, std::unique_ptr<content::MediaStreamUI>());
+  cb.Run(devices, content::MEDIA_DEVICE_OK,
+         std::unique_ptr<content::MediaStreamUI>());
 }
 
-void MediaStreamDevicesController::Deny(content::MediaStreamRequestResult result) {
+void MediaStreamDevicesController::Deny(
+    content::MediaStreamRequestResult result) {
   content::MediaResponseCallback cb = callback_;
   callback_.Reset();
   cb.Run(content::MediaStreamDevices(),

--- a/browser/net/devtools_network_controller.h
+++ b/browser/net/devtools_network_controller.h
@@ -24,8 +24,9 @@ class DevToolsNetworkController {
   DevToolsNetworkInterceptor* GetInterceptor(const std::string& client_id);
 
  private:
-  using InterceptorMap = base::ScopedPtrHashMap<std::string,
-                                                std::unique_ptr<DevToolsNetworkInterceptor>>;
+  using InterceptorMap =
+      base::ScopedPtrHashMap<std::string,
+                             std::unique_ptr<DevToolsNetworkInterceptor>>;
 
   std::unique_ptr<DevToolsNetworkInterceptor> appcache_interceptor_;
   InterceptorMap interceptors_;

--- a/browser/net/devtools_network_controller_handle.h
+++ b/browser/net/devtools_network_controller_handle.h
@@ -31,8 +31,9 @@ class DevToolsNetworkControllerHandle {
 
  private:
   void LazyInitialize();
-  void SetNetworkStateOnIO(const std::string& client_id,
-                           std::unique_ptr<DevToolsNetworkConditions> conditions);
+  void SetNetworkStateOnIO(
+      const std::string& client_id,
+      std::unique_ptr<DevToolsNetworkConditions> conditions);
 
   std::unique_ptr<DevToolsNetworkController> controller_;
 

--- a/browser/net/devtools_network_protocol_handler.cc
+++ b/browser/net/devtools_network_protocol_handler.cc
@@ -30,7 +30,8 @@ const char kErrorMessage[] = "message";
 }  //  namespace params
 
 const char kEmulateNetworkConditions[] = "Network.emulateNetworkConditions";
-const char kCanEmulateNetworkConditions[] = "Network.canEmulateNetworkConditions";
+const char kCanEmulateNetworkConditions[] =
+    "Network.canEmulateNetworkConditions";
 const char kId[] = "id";
 const char kMethod[] = "method";
 const char kParams[] = "params";

--- a/browser/net/devtools_network_transaction_factory.h
+++ b/browser/net/devtools_network_transaction_factory.h
@@ -21,13 +21,14 @@ class DevToolsNetworkTransactionFactory : public net::HttpTransactionFactory {
   ~DevToolsNetworkTransactionFactory() override;
 
   // net::HttpTransactionFactory:
-  int CreateTransaction(net::RequestPriority priority,
-                        std::unique_ptr<net::HttpTransaction>* transaction) override;
+  int CreateTransaction(
+      net::RequestPriority priority,
+      std::unique_ptr<net::HttpTransaction>* transaction) override;
   net::HttpCache* GetCache() override;
   net::HttpNetworkSession* GetSession() override;
 
  private:
-  DevToolsNetworkController*  controller_;
+  DevToolsNetworkController* controller_;
   std::unique_ptr<net::HttpTransactionFactory> network_layer_;
 
   DISALLOW_COPY_AND_ASSIGN(DevToolsNetworkTransactionFactory);

--- a/browser/net/devtools_network_upload_data_stream.cc
+++ b/browser/net/devtools_network_upload_data_stream.cc
@@ -81,7 +81,7 @@ int DevToolsNetworkUploadDataStream::ThrottleRead(int result) {
 }
 
 void DevToolsNetworkUploadDataStream::ThrottleCallback(
-   int result, int64_t bytes) {
+    int result, int64_t bytes) {
   throttled_byte_count_ = bytes;
   OnReadCompleted(result);
 }

--- a/browser/net_log.cc
+++ b/browser/net_log.cc
@@ -40,7 +40,8 @@ void NetLog::StartLogging(net::URLRequestContext* url_request_context) {
   if (!command_line->HasSwitch(switches::kLogNetLog))
     return;
 
-  base::FilePath log_path = command_line->GetSwitchValuePath(switches::kLogNetLog);
+  base::FilePath log_path =
+      command_line->GetSwitchValuePath(switches::kLogNetLog);
 #if defined(OS_WIN)
   log_file_.reset(_wfopen(log_path.value().c_str(), L"w"));
 #elif defined(OS_POSIX)

--- a/browser/network_delegate.cc
+++ b/browser/network_delegate.cc
@@ -25,7 +25,8 @@ const char kIgnoreConnectionsLimit[] = "ignore-connections-limit";
 NetworkDelegate::NetworkDelegate() {
   auto command_line = base::CommandLine::ForCurrentProcess();
   if (command_line->HasSwitch(kIgnoreConnectionsLimit)) {
-    std::string value = command_line->GetSwitchValueASCII(kIgnoreConnectionsLimit);
+    std::string value =
+        command_line->GetSwitchValueASCII(kIgnoreConnectionsLimit);
     ignore_connections_limit_domains_ = base::SplitString(
         value, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
   }

--- a/browser/permission_manager.h
+++ b/browser/permission_manager.h
@@ -22,14 +22,16 @@ class PermissionManager : public content::PermissionManager {
       content::RenderFrameHost* render_frame_host,
       const GURL& requesting_origin,
       bool user_gesture,
-      const base::Callback<void(blink::mojom::PermissionStatus)>& callback) override;
+      const base::Callback<void(blink::mojom::PermissionStatus)>& callback)
+      override;
   int RequestPermissions(
       const std::vector<content::PermissionType>& permissions,
       content::RenderFrameHost* render_frame_host,
       const GURL& requesting_origin,
       bool user_gesture,
-      const base::Callback<void(
-          const std::vector<blink::mojom::PermissionStatus>&)>& callback) override;
+      const base::Callback<
+          void(const std::vector<blink::mojom::PermissionStatus>&)>& callback)
+      override;
   void CancelPermissionRequest(int request_id) override;
   void ResetPermission(content::PermissionType permission,
                        const GURL& requesting_origin,
@@ -45,7 +47,8 @@ class PermissionManager : public content::PermissionManager {
       content::PermissionType permission,
       const GURL& requesting_origin,
       const GURL& embedding_origin,
-      const base::Callback<void(blink::mojom::PermissionStatus)>& callback) override;
+      const base::Callback<void(blink::mojom::PermissionStatus)>& callback)
+      override;
   void UnsubscribePermissionStatusChange(int subscription_id) override;
 
  private:

--- a/browser/platform_notification_service.cc
+++ b/browser/platform_notification_service.cc
@@ -45,7 +45,8 @@ PlatformNotificationService::PlatformNotificationService(
 
 PlatformNotificationService::~PlatformNotificationService() {}
 
-blink::mojom::PermissionStatus PlatformNotificationService::CheckPermissionOnUIThread(
+blink::mojom::PermissionStatus
+PlatformNotificationService::CheckPermissionOnUIThread(
     content::BrowserContext* browser_context,
     const GURL& origin,
     int render_process_id) {
@@ -53,7 +54,8 @@ blink::mojom::PermissionStatus PlatformNotificationService::CheckPermissionOnUIT
   return blink::mojom::PermissionStatus::GRANTED;
 }
 
-blink::mojom::PermissionStatus PlatformNotificationService::CheckPermissionOnIOThread(
+blink::mojom::PermissionStatus
+PlatformNotificationService::CheckPermissionOnIOThread(
     content::ResourceContext* resource_context,
     const GURL& origin,
     int render_process_id) {

--- a/browser/url_request_context_getter.cc
+++ b/browser/url_request_context_getter.cc
@@ -200,7 +200,8 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
             net::HttpUtil::GenerateAcceptLanguageHeader(accept_lang),
             user_agent_)));
 
-    std::unique_ptr<net::HostResolver> host_resolver(net::HostResolver::CreateDefaultResolver(nullptr));
+    std::unique_ptr<net::HostResolver> host_resolver(
+        net::HostResolver::CreateDefaultResolver(nullptr));
 
     // --host-resolver-rules
     if (command_line.HasSwitch(::switches::kHostResolverRules)) {
@@ -301,7 +302,8 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
     // --host-rules
     if (command_line.HasSwitch(switches::kHostRules)) {
       host_mapping_rules_.reset(new net::HostMappingRules);
-      host_mapping_rules_->SetRulesFromString(command_line.GetSwitchValueASCII(switches::kHostRules));
+      host_mapping_rules_->SetRulesFromString(
+          command_line.GetSwitchValueASCII(switches::kHostRules));
       network_session_params.host_mapping_rules = host_mapping_rules_.get();
     }
 

--- a/browser/url_request_context_getter.cc
+++ b/browser/url_request_context_getter.cc
@@ -69,7 +69,8 @@ std::string URLRequestContextGetter::Delegate::GetUserAgent() {
 std::unique_ptr<net::URLRequestJobFactory>
 URLRequestContextGetter::Delegate::CreateURLRequestJobFactory(
     content::ProtocolHandlerMap* protocol_handlers) {
-  std::unique_ptr<net::URLRequestJobFactoryImpl> job_factory(new net::URLRequestJobFactoryImpl);
+  std::unique_ptr<net::URLRequestJobFactoryImpl> job_factory(
+      new net::URLRequestJobFactoryImpl);
 
   for (auto& it : *protocol_handlers) {
     job_factory->SetProtocolHandler(
@@ -89,7 +90,8 @@ URLRequestContextGetter::Delegate::CreateURLRequestJobFactory(
 }
 
 net::HttpCache::BackendFactory*
-URLRequestContextGetter::Delegate::CreateHttpCacheBackendFactory(const base::FilePath& base_path) {
+URLRequestContextGetter::Delegate::CreateHttpCacheBackendFactory(
+    const base::FilePath& base_path) {
   base::FilePath cache_path = base_path.Append(FILE_PATH_LITERAL("Cache"));
   return new net::HttpCache::DefaultBackend(
       net::DISK_CACHE,
@@ -104,11 +106,13 @@ URLRequestContextGetter::Delegate::CreateCertVerifier() {
   return net::CertVerifier::CreateDefault();
 }
 
-net::SSLConfigService* URLRequestContextGetter::Delegate::CreateSSLConfigService() {
+net::SSLConfigService*
+URLRequestContextGetter::Delegate::CreateSSLConfigService() {
   return new net::SSLConfigServiceDefaults;
 }
 
-std::vector<std::string> URLRequestContextGetter::Delegate::GetCookieableSchemes() {
+std::vector<std::string>
+URLRequestContextGetter::Delegate::GetCookieableSchemes() {
   return { "http", "https", "ws", "wss" };
 }
 
@@ -177,7 +181,8 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
     network_delegate_.reset(delegate_->CreateNetworkDelegate());
     url_request_context_->set_network_delegate(network_delegate_.get());
 
-    storage_.reset(new net::URLRequestContextStorage(url_request_context_.get()));
+    storage_.reset(
+        new net::URLRequestContextStorage(url_request_context_.get()));
 
     auto cookie_path = in_memory_ ?
         base::FilePath() : base_path_.Append(FILE_PATH_LITERAL("Cookies"));
@@ -261,7 +266,8 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
     // --auth-negotiate-delegate-whitelist
     if (command_line.HasSwitch(switches::kAuthNegotiateDelegateWhitelist)) {
       http_auth_preferences_->set_delegate_whitelist(
-          command_line.GetSwitchValueASCII(switches::kAuthNegotiateDelegateWhitelist));
+          command_line.GetSwitchValueASCII(
+              switches::kAuthNegotiateDelegateWhitelist));
     }
 
     auto auth_handler_factory =
@@ -309,7 +315,8 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
 
     // Give |storage_| ownership at the end in case it's |mapped_host_resolver|.
     storage_->set_host_resolver(std::move(host_resolver));
-    network_session_params.host_resolver = url_request_context_->host_resolver();
+    network_session_params.host_resolver =
+        url_request_context_->host_resolver();
 
     http_network_session_.reset(
         new net::HttpNetworkSession(network_session_params));
@@ -324,7 +331,8 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
       storage_->set_http_transaction_factory(base::WrapUnique(
           new net::HttpCache(
               base::WrapUnique(new DevToolsNetworkTransactionFactory(
-                  network_controller_handle_->GetController(), http_network_session_.get())),
+                  network_controller_handle_->GetController(),
+                  http_network_session_.get())),
               std::move(backend),
               false)));
     } else {
@@ -356,7 +364,8 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
   return url_request_context_.get();
 }
 
-scoped_refptr<base::SingleThreadTaskRunner> URLRequestContextGetter::GetNetworkTaskRunner() const {
+scoped_refptr<base::SingleThreadTaskRunner>
+URLRequestContextGetter::GetNetworkTaskRunner() const {
   return BrowserThread::GetTaskRunnerForThread(BrowserThread::IO);
 }
 

--- a/browser/url_request_context_getter.h
+++ b/browser/url_request_context_getter.h
@@ -47,8 +47,7 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
     }
     virtual std::string GetUserAgent();
     virtual std::unique_ptr<net::URLRequestJobFactory>
-        CreateURLRequestJobFactory(
-            content::ProtocolHandlerMap* protocol_handlers);
+    CreateURLRequestJobFactory(content::ProtocolHandlerMap* protocol_handlers);
     virtual net::HttpCache::BackendFactory* CreateHttpCacheBackendFactory(
         const base::FilePath& base_path);
     virtual std::unique_ptr<net::CertVerifier> CreateCertVerifier();
@@ -75,7 +74,8 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
 
   // net::URLRequestContextGetter:
   net::URLRequestContext* GetURLRequestContext() override;
-  scoped_refptr<base::SingleThreadTaskRunner> GetNetworkTaskRunner() const override;
+  scoped_refptr<base::SingleThreadTaskRunner> GetNetworkTaskRunner()
+      const override;
 
   net::HostResolver* host_resolver();
   net::URLRequestJobFactory* job_factory() const { return job_factory_; }

--- a/browser/views/inspectable_web_contents_view_views.cc
+++ b/browser/views/inspectable_web_contents_view_views.cc
@@ -48,7 +48,9 @@ class DevToolsWindowDelegate : public views::ClientView,
   views::Widget* GetWidget() override { return widget_; }
   const views::Widget* GetWidget() const override { return widget_; }
   views::View* GetContentsView() override { return view_; }
-  views::ClientView* CreateClientView(views::Widget* widget) override { return this; }
+  views::ClientView* CreateClientView(views::Widget* widget) override {
+    return this;
+  }
 
   // views::ClientView:
   bool CanClose() override {
@@ -85,10 +87,12 @@ InspectableWebContentsViewViews::InspectableWebContentsViewViews(
 
   if (inspectable_web_contents_->GetWebContents()->GetNativeView()) {
     views::WebView* contents_web_view = new views::WebView(nullptr);
-    contents_web_view->SetWebContents(inspectable_web_contents_->GetWebContents());
+    contents_web_view->SetWebContents(
+        inspectable_web_contents_->GetWebContents());
     contents_web_view_ = contents_web_view;
   } else {
-    contents_web_view_ = new views::Label(base::ASCIIToUTF16("No content under offscreen mode"));
+    contents_web_view_ = new views::Label(
+        base::ASCIIToUTF16("No content under offscreen mode"));
   }
 
   devtools_web_view_->SetVisible(false);
@@ -98,7 +102,8 @@ InspectableWebContentsViewViews::InspectableWebContentsViewViews(
 
 InspectableWebContentsViewViews::~InspectableWebContentsViewViews() {
   if (devtools_window_)
-    inspectable_web_contents()->SaveDevToolsBounds(devtools_window_->GetWindowBoundsInScreen());
+    inspectable_web_contents()->SaveDevToolsBounds(
+        devtools_window_->GetWindowBoundsInScreen());
 }
 
 views::View* InspectableWebContentsViewViews::GetView() {
@@ -117,7 +122,8 @@ void InspectableWebContentsViewViews::ShowDevTools() {
   if (devtools_window_) {
     devtools_window_web_view_->SetWebContents(
         inspectable_web_contents_->GetDevToolsWebContents());
-    devtools_window_->SetBounds(inspectable_web_contents()->GetDevToolsBounds());
+    devtools_window_->SetBounds(
+        inspectable_web_contents()->GetDevToolsBounds());
     devtools_window_->Show();
   } else {
     devtools_web_view_->SetVisible(true);
@@ -134,7 +140,8 @@ void InspectableWebContentsViewViews::CloseDevTools() {
 
   devtools_visible_ = false;
   if (devtools_window_) {
-    inspectable_web_contents()->SaveDevToolsBounds(devtools_window_->GetWindowBoundsInScreen());
+    inspectable_web_contents()->SaveDevToolsBounds(
+        devtools_window_->GetWindowBoundsInScreen());
     devtools_window_.reset();
     devtools_window_web_view_ = nullptr;
     devtools_window_delegate_ = nullptr;
@@ -164,9 +171,10 @@ void InspectableWebContentsViewViews::SetIsDocked(bool docked) {
   if (!docked) {
     devtools_window_.reset(new views::Widget);
     devtools_window_web_view_ = new views::WebView(NULL);
-    devtools_window_delegate_ = new DevToolsWindowDelegate(this,
-                                                           devtools_window_web_view_,
-                                                           devtools_window_.get());
+    devtools_window_delegate_ = new DevToolsWindowDelegate(
+        this,
+        devtools_window_web_view_
+        devtools_window_.get());
 
     views::Widget::InitParams params;
     params.ownership = views::Widget::InitParams::WIDGET_OWNS_NATIVE_WIDGET;
@@ -176,7 +184,8 @@ void InspectableWebContentsViewViews::SetIsDocked(bool docked) {
 #if defined(USE_X11)
     params.wm_role_name = "devtools";
     if (GetDelegate())
-      GetDelegate()->GetDevToolsWindowWMClass(&params.wm_class_name, &params.wm_class_class);
+      GetDelegate()->GetDevToolsWindowWMClass(&params.wm_class_name,
+                                              &params.wm_class_class);
 #endif
 
     devtools_window_->Init(params);

--- a/browser/views/inspectable_web_contents_view_views.cc
+++ b/browser/views/inspectable_web_contents_view_views.cc
@@ -173,7 +173,7 @@ void InspectableWebContentsViewViews::SetIsDocked(bool docked) {
     devtools_window_web_view_ = new views::WebView(NULL);
     devtools_window_delegate_ = new DevToolsWindowDelegate(
         this,
-        devtools_window_web_view_
+        devtools_window_web_view_,
         devtools_window_.get());
 
     views::Widget::InitParams params;

--- a/browser/views/inspectable_web_contents_view_views.h
+++ b/browser/views/inspectable_web_contents_view_views.h
@@ -14,7 +14,7 @@ class Widget;
 
 namespace brightray {
 
-namespace {
+namespace { // NOLINT
 class DevToolsWindowDelegate;
 }
 

--- a/browser/views/views_delegate.cc
+++ b/browser/views/views_delegate.cc
@@ -48,7 +48,8 @@ void ViewsDelegate::NotifyMenuItemFocused(
 #if defined(OS_WIN)
 HICON ViewsDelegate::GetDefaultWindowIcon() const {
   // Use current exe's icon as default window icon.
-  return LoadIcon(GetModuleHandle(NULL), MAKEINTRESOURCE(1  /* IDR_MAINFRAME */));
+  return LoadIcon(GetModuleHandle(NULL),
+                  MAKEINTRESOURCE(1  /* IDR_MAINFRAME */));
 }
 
 HICON ViewsDelegate::GetSmallWindowIcon() const {

--- a/browser/win/notification_presenter_win.cc
+++ b/browser/win/notification_presenter_win.cc
@@ -38,7 +38,8 @@ bool SaveIconToPath(const SkBitmap& bitmap, const base::FilePath& path) {
 NotificationPresenter* NotificationPresenter::Create() {
   if (!WindowsToastNotification::Initialize())
     return nullptr;
-  std::unique_ptr<NotificationPresenterWin> presenter(new NotificationPresenterWin);
+  std::unique_ptr<NotificationPresenterWin> presenter(
+      new NotificationPresenterWin);
   if (!presenter->Init())
     return nullptr;
   return presenter.release();

--- a/browser/win/notification_presenter_win.cc
+++ b/browser/win/notification_presenter_win.cc
@@ -1,5 +1,6 @@
 // Copyright (c) 2012 The Chromium Authors. All rights reserved.
-// Copyright (c) 2015 Felix Rieseberg <feriese@microsoft.com> and Jason Poon <jason.poon@microsoft.com>. All rights reserved.
+// Copyright (c) 2015 Felix Rieseberg <feriese@microsoft.com> and
+// Jason Poon <jason.poon@microsoft.com>. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-CHROMIUM file.
 

--- a/browser/win/notification_presenter_win.h
+++ b/browser/win/notification_presenter_win.h
@@ -10,9 +10,15 @@
 //   icon: "file:///C:/Path/To/Your/Image.png"
 // });
 
-// windowsNotification.onshow  = function () { console.log("Notification shown") };
-// windowsNotification.onclick = function () { console.log("Notification clicked") };
-// windowsNotification.onclose = function () { console.log("Notification dismissed") };
+// windowsNotification.onshow  = function () {
+//   console.log("Notification shown")
+// };
+// windowsNotification.onclick = function () {
+//   console.log("Notification clicked")
+// };
+// windowsNotification.onclose = function () {
+//   console.log("Notification dismissed")
+// };
 
 #ifndef BRIGHTRAY_BROWSER_WIN_NOTIFICATION_PRESENTER_WIN_H_
 #define BRIGHTRAY_BROWSER_WIN_NOTIFICATION_PRESENTER_WIN_H_

--- a/browser/win/notification_presenter_win.h
+++ b/browser/win/notification_presenter_win.h
@@ -1,12 +1,13 @@
 // Copyright (c) 2012 The Chromium Authors. All rights reserved.
-// Copyright (c) 2015 Felix Rieseberg <feriese@microsoft.com> and Jason Poon <jason.poon@microsoft.com>. All rights reserved.
+// Copyright (c) 2015 Felix Rieseberg <feriese@microsoft.com> and
+// Jason Poon <jason.poon@microsoft.com>. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-CHROMIUM file.
 
 // Usage Example (JavaScript:
 // var windowsNotification = new Notification("Test Title", {
-// 	body: "Hi, I'm an example body. How are you?",
-// 	icon: "file:///C:/Path/To/Your/Image.png"
+//   body: "Hi, I'm an example body. How are you?",
+//   icon: "file:///C:/Path/To/Your/Image.png"
 // });
 
 // windowsNotification.onshow  = function () { console.log("Notification shown") };
@@ -40,6 +41,6 @@ class NotificationPresenterWin : public NotificationPresenter {
   DISALLOW_COPY_AND_ASSIGN(NotificationPresenterWin);
 };
 
-}  // namespace
+}  // namespace brightray
 
 #endif  // BRIGHTRAY_BROWSER_WIN_NOTIFICATION_PRESENTER_WIN_H_

--- a/browser/win/scoped_hstring.h
+++ b/browser/win/scoped_hstring.h
@@ -5,18 +5,18 @@
 #ifndef BRIGHTRAY_BROWSER_WIN_SCOPED_HSTRING_H_
 #define BRIGHTRAY_BROWSER_WIN_SCOPED_HSTRING_H_
 
-#include <string>
-
 #include <hstring.h>
 #include <windows.h>
+
+#include <string>
 
 #include "base/macros.h"
 
 class ScopedHString {
  public:
   // Copy from |source|.
-  ScopedHString(const wchar_t* source);
-  ScopedHString(const std::wstring& source);
+  explicit ScopedHString(const wchar_t* source);
+  explicit ScopedHString(const std::wstring& source);
   // Create empty string.
   ScopedHString();
   ~ScopedHString();

--- a/browser/win/windows_toast_notification.h
+++ b/browser/win/windows_toast_notification.h
@@ -1,6 +1,9 @@
-// Copyright (c) 2015 Felix Rieseberg <feriese@microsoft.com> and Jason Poon <jason.poon@microsoft.com>. All rights reserved.
-// Copyright (c) 2015 Ryan McShane <rmcshane@bandwidth.com> and Brandon Smith <bsmith@bandwidth.com>
-// Thanks to both of those folks mentioned above who first thought up a bunch of this code
+// Copyright (c) 2015 Felix Rieseberg <feriese@microsoft.com> and Jason Poon
+// <jason.poon@microsoft.com>. All rights reserved.
+// Copyright (c) 2015 Ryan McShane <rmcshane@bandwidth.com> and Brandon Smith
+// <bsmith@bandwidth.com>
+// Thanks to both of those folks mentioned above who first thought up a bunch of
+// this code
 // and released it as MIT to the world.
 
 #ifndef BRIGHTRAY_BROWSER_WIN_WINDOWS_TOAST_NOTIFICATION_H_
@@ -12,21 +15,28 @@
 
 #include "browser/notification.h"
 
-using namespace Microsoft::WRL;
+using Microsoft::WRL::ClassicCom;
+using Microsoft::WRL::ComPtr;
+using Microsoft::WRL::Make;
+using Microsoft::WRL::RuntimeClass;
+using Microsoft::WRL::RuntimeClassFlags;
 
 class ScopedHString;
 
 namespace brightray {
 
 using DesktopToastActivatedEventHandler =
-    ABI::Windows::Foundation::ITypedEventHandler<ABI::Windows::UI::Notifications::ToastNotification*,
-    IInspectable*>;
+    ABI::Windows::Foundation::ITypedEventHandler<
+        ABI::Windows::UI::Notifications::ToastNotification*,
+        IInspectable*>;
 using DesktopToastDismissedEventHandler =
-    ABI::Windows::Foundation::ITypedEventHandler<ABI::Windows::UI::Notifications::ToastNotification*,
-    ABI::Windows::UI::Notifications::ToastDismissedEventArgs*>;
+    ABI::Windows::Foundation::ITypedEventHandler<
+        ABI::Windows::UI::Notifications::ToastNotification*,
+        ABI::Windows::UI::Notifications::ToastDismissedEventArgs*>;
 using DesktopToastFailedEventHandler =
-    ABI::Windows::Foundation::ITypedEventHandler<ABI::Windows::UI::Notifications::ToastNotification*,
-    ABI::Windows::UI::Notifications::ToastFailedEventArgs*>;
+    ABI::Windows::Foundation::ITypedEventHandler<
+        ABI::Windows::UI::Notifications::ToastNotification*,
+        ABI::Windows::UI::Notifications::ToastFailedEventArgs*>;
 
 class WindowsToastNotification : public Notification {
  public:
@@ -50,12 +60,14 @@ class WindowsToastNotification : public Notification {
  private:
   friend class ToastEventHandler;
 
-  bool GetToastXml(ABI::Windows::UI::Notifications::IToastNotificationManagerStatics* toastManager,
-                   const std::wstring& title,
-                   const std::wstring& msg,
-                   const std::wstring& icon_path,
-                   const bool silent,
-                   ABI::Windows::Data::Xml::Dom::IXmlDocument** toastXml);
+  bool GetToastXml(
+      ABI::Windows::UI::Notifications::IToastNotificationManagerStatics*
+          toastManager,
+      const std::wstring& title,
+      const std::wstring& msg,
+      const std::wstring& icon_path,
+      const bool silent,
+      ABI::Windows::Data::Xml::Dom::IXmlDocument** toastXml);
   bool SetXmlAudioSilent(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc);
   bool SetXmlText(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
                   const std::wstring& text);
@@ -71,34 +83,45 @@ class WindowsToastNotification : public Notification {
   bool AppendTextToXml(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
                        ABI::Windows::Data::Xml::Dom::IXmlNode* node,
                        const std::wstring& text);
-  bool SetupCallbacks(ABI::Windows::UI::Notifications::IToastNotification* toast);
-  bool RemoveCallbacks(ABI::Windows::UI::Notifications::IToastNotification* toast);
+  bool SetupCallbacks(
+      ABI::Windows::UI::Notifications::IToastNotification* toast);
+  bool RemoveCallbacks(
+      ABI::Windows::UI::Notifications::IToastNotification* toast);
 
-  static ComPtr<ABI::Windows::UI::Notifications::IToastNotificationManagerStatics> toast_manager_;
-  static ComPtr<ABI::Windows::UI::Notifications::IToastNotifier> toast_notifier_;
+  static ComPtr<
+      ABI::Windows::UI::Notifications::IToastNotificationManagerStatics>
+      toast_manager_;
+  static ComPtr<ABI::Windows::UI::Notifications::IToastNotifier>
+      toast_notifier_;
 
   EventRegistrationToken activated_token_;
   EventRegistrationToken dismissed_token_;
   EventRegistrationToken failed_token_;
 
   ComPtr<ToastEventHandler> event_handler_;
-  ComPtr<ABI::Windows::UI::Notifications::IToastNotification> toast_notification_;
+  ComPtr<ABI::Windows::UI::Notifications::IToastNotification>
+      toast_notification_;
 
   DISALLOW_COPY_AND_ASSIGN(WindowsToastNotification);
 };
-
 
 class ToastEventHandler : public RuntimeClass<RuntimeClassFlags<ClassicCom>,
                                               DesktopToastActivatedEventHandler,
                                               DesktopToastDismissedEventHandler,
                                               DesktopToastFailedEventHandler> {
  public:
-  ToastEventHandler(Notification* notification);
+  explicit ToastEventHandler(Notification* notification);
   ~ToastEventHandler();
 
-  IFACEMETHODIMP Invoke(ABI::Windows::UI::Notifications::IToastNotification* sender, IInspectable* args);
-  IFACEMETHODIMP Invoke(ABI::Windows::UI::Notifications::IToastNotification* sender, ABI::Windows::UI::Notifications::IToastDismissedEventArgs* e);
-  IFACEMETHODIMP Invoke(ABI::Windows::UI::Notifications::IToastNotification* sender, ABI::Windows::UI::Notifications::IToastFailedEventArgs* e);
+  IFACEMETHODIMP Invoke(
+      ABI::Windows::UI::Notifications::IToastNotification* sender,
+      IInspectable* args);
+  IFACEMETHODIMP Invoke(
+      ABI::Windows::UI::Notifications::IToastNotification* sender,
+      ABI::Windows::UI::Notifications::IToastDismissedEventArgs* e);
+  IFACEMETHODIMP Invoke(
+      ABI::Windows::UI::Notifications::IToastNotification* sender,
+      ABI::Windows::UI::Notifications::IToastFailedEventArgs* e);
 
  private:
   base::WeakPtr<Notification> notification_;  // weak ref.

--- a/common/main_delegate.cc
+++ b/common/main_delegate.cc
@@ -61,9 +61,9 @@ void InitializeResourceBundle(const std::string& locale) {
   bundle.AddDataPackFromPath(
       pak_dir.Append(FILE_PATH_LITERAL("pdf_viewer_resources.pak")),
       ui::GetSupportedScaleFactors()[0]);
-  bundle.AddDataPackFromPath(
-      pak_dir.Append(FILE_PATH_LITERAL("blink_image_resources_200_percent.pak")),
-      ui::SCALE_FACTOR_200P);
+  bundle.AddDataPackFromPath(pak_dir.Append(FILE_PATH_LITERAL(
+                                 "blink_image_resources_200_percent.pak")),
+                             ui::SCALE_FACTOR_200P);
   bundle.AddDataPackFromPath(
       pak_dir.Append(FILE_PATH_LITERAL("content_resources_200_percent.pak")),
       ui::SCALE_FACTOR_200P);
@@ -75,7 +75,6 @@ void InitializeResourceBundle(const std::string& locale) {
       ui::SCALE_FACTOR_200P);
 #endif
 }
-
 
 MainDelegate::MainDelegate() {
 }

--- a/common/switches.cc
+++ b/common/switches.cc
@@ -47,7 +47,8 @@ const char kDisableHttp2[] = "disable-http2";
 const char kAuthServerWhitelist[] = "auth-server-whitelist";
 
 // Whitelist containing servers for which Kerberos delegation is allowed.
-const char kAuthNegotiateDelegateWhitelist[] = "auth-negotiate-delegate-whitelist";
+const char kAuthNegotiateDelegateWhitelist[] =
+    "auth-negotiate-delegate-whitelist";
 
 // Ignores certificate-related errors.
 const char kIgnoreCertificateErrors[] = "ignore-certificate-errors";

--- a/script/cibuild
+++ b/script/cibuild
@@ -2,6 +2,8 @@
 
 set -ex
 
+script/cpplint
+
 # Make cloned repository complete
 git fetch --unshallow origin HEAD
 

--- a/script/cpplint
+++ b/script/cpplint
@@ -7,7 +7,7 @@ import sys
 
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-CPPLINT = os.path.join(SOURCE_ROOT, 'vendor', 'google-styleguide', 'trunk', 'cpplint', 'cpplint.py')
+CPPLINT = os.path.join(SOURCE_ROOT, 'vendor', 'libchromiumcontent', 'vendor', 'depot_tools', 'cpplint.py')
 LINE_LENGTH = 100
 
 IGNORED_FILES = [

--- a/script/cpplint
+++ b/script/cpplint
@@ -8,20 +8,10 @@ import sys
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 CPPLINT = os.path.join(SOURCE_ROOT, 'vendor', 'libchromiumcontent', 'vendor', 'depot_tools', 'cpplint.py')
-LINE_LENGTH = 100
 
 IGNORED_FILES = [
     os.path.join('browser', 'mac', 'bry_inspectable_web_contents_view.h'),
 ]
-
-FILTERS = [
-  '-build/header_guard',
-  '-build/include_what_you_use',
-  '-legal/copyright',
-  # cpplint doesn't like the BOOL& parameters that ui::WindowImpl uses.
-  '-runtime/references',
-]
-
 
 def main():
   os.chdir(SOURCE_ROOT)
@@ -41,7 +31,7 @@ def list_files(directories, filters):
 
 
 def cpplint(files):
-  return subprocess.call([sys.executable, CPPLINT, '--linelength=%d' % LINE_LENGTH, '--filter=' + ','.join(FILTERS)] + list(files))
+  return subprocess.call([sys.executable, CPPLINT] + list(files))
 
 
 if __name__ == '__main__':

--- a/script/cpplint
+++ b/script/cpplint
@@ -11,6 +11,8 @@ CPPLINT = os.path.join(SOURCE_ROOT, 'vendor', 'libchromiumcontent', 'vendor', 'd
 
 IGNORED_FILES = [
     os.path.join('browser', 'mac', 'bry_inspectable_web_contents_view.h'),
+    os.path.join('browser', 'mac', 'event_dispatching_window.h'),
+    os.path.join('browser', 'mac', 'notification_center_delegate.h'),
 ]
 
 def main():


### PR DESCRIPTION
This pull request adds `script/cpplint` to `script/cibuild` to lint on Travis and AppVeyor.

Also formats the code to pass the linter rules used in Electron.